### PR TITLE
feat: OHOS 播放器 DLNA 投屏到电视/盒子

### DIFF
--- a/entry/src/main/ets/common/utils/CastSession.ets
+++ b/entry/src/main/ets/common/utils/CastSession.ets
@@ -1,39 +1,50 @@
 import { DlnaClient } from './DlnaClient';
-import { DlnaDevice, DlnaPositionInfo } from './DlnaTypes';
+import { CastPhase, DlnaDevice } from './DlnaTypes';
+import { CastPollHost, CastSessionPoll } from './CastSessionPoll';
 
 /**
- * Lightweight cast session that outlives the cast dialog.
- * Keeps device state + optional background GetPositionInfo poll so
- * screen-off / brief background does not tear down TV playback, and
- * progress stays fresh when the sheet reopens.
- *
- * Also watches transport / poll health: when the TV stops or drops off
- * the network, clearLocal() only (never Stop SOAP) and notify UI.
+ * Unique cast session: device, phase, poll, Stop, launch confirm, EOS vs disconnect.
  */
-export class CastSession {
+export class CastSession implements CastPollHost {
+  private static readonly TAG: string = '[CastSession]';
+  private static readonly SLOW_MS: number = 35000;
+  private static readonly FAST_MS: number = 20000;
+  private static readonly HUD_POLL_MS: number = 1000;
+  private static readonly BG_POLL_MS: number = 2000;
+  private static readonly SLOW_NAME_SUBSTR: string[] = ['macast', 'kodi', 'mpv', 'xbmc'];
+
   device: DlnaDevice | null = null;
   positionSec: number = 0;
   durationSec: number = 0;
   volume: number = 50;
   volumeSupported: boolean = false;
   transportState: string = '';
+  phase: string = CastPhase.IDLE;
+  relTimeUnavailable: boolean = false;
+  needRelTimeToast: boolean = false;
+  pendingStartSec: number = -1;
 
-  /** Fired after clearLocal on remote STOPPED / poll-fail disconnect. Position is the last known TV time. */
-  onRemoteDisconnected: ((positionSec: number) => void) | null = null;
+  onFailed: ((positionSec: number) => void) | null = null;
+  onCompleted: (() => void) | null = null;
+  onDisconnected: ((positionSec: number) => void) | null = null;
+  onState: (() => void) | null = null;
 
-  private client: DlnaClient = new DlnaClient();
+  client: DlnaClient = new DlnaClient();
+  pollToken: number = 0;
+  pollBusy: boolean = false;
+  terminal: boolean = false;
+  failStreak: number = 0;
+  relNiStreak: number = 0;
+  originMs: number = 0;
+  launchAtMs: number = 0;
+  timeoutMs: number = CastSession.FAST_MS;
+  stoppedStreak: number = 0;
+  eosStopStreak: number = 0;
+  startSeekTries: number = 0;
+  startSeeking: boolean = false;
   private pollTimer: number = -1;
-  private pollToken: number = 0;
-
-  /** True once we have seen PLAYING or TRANSITIONING after attach. */
-  private everPlayed: boolean = false;
-  private stoppedStreak: number = 0;
-  private failStreak: number = 0;
-
-  /** Consecutive STOPPED / NO_MEDIA_PRESENT polls after everPlayed. */
-  private static readonly STOPPED_THRESHOLD: number = 3;
-  /** Consecutive failed GetPositionInfo+GetTransportInfo polls while active. */
-  private static readonly FAIL_THRESHOLD: number = 3;
+  private hudPolling: boolean = false;
+  private poller: CastSessionPoll = new CastSessionPoll();
 
   get active(): boolean {
     return this.device !== null;
@@ -47,15 +58,35 @@ export class CastSession {
     return this.device ? this.device.friendlyName : '';
   }
 
+  /** Set device only. Progress is assigned by beginLaunch / replaceUri. */
   attach(device: DlnaDevice): void {
     this.device = device;
-    this.positionSec = 0;
-    this.durationSec = 0;
     this.transportState = '';
+    this.relTimeUnavailable = false;
+    this.needRelTimeToast = false;
+    this.relNiStreak = 0;
     this.resetHealthCounters();
+    this.timeoutMs = CastSession.matchSlow(device) ? CastSession.SLOW_MS : CastSession.FAST_MS;
   }
 
-  /** Clear local session state without sending Stop to the renderer. */
+  beginLaunch(positionSec: number, durationSec: number): void {
+    if (positionSec >= 0) {
+      this.positionSec = positionSec;
+    }
+    if (durationSec > 0) {
+      this.durationSec = durationSec;
+    }
+    this.pendingStartSec = positionSec >= 2 ? positionSec : -1;
+    this.startSeekTries = 0;
+    this.startSeeking = false;
+    this.originMs = 0;
+    this.terminal = false;
+    this.launchAtMs = Date.now();
+    this.setPhase(CastPhase.LAUNCHING);
+    this.startPoll(this.pollInterval());
+    this.emitState();
+  }
+
   clearLocal(): void {
     this.stopPoll();
     this.device = null;
@@ -64,19 +95,32 @@ export class CastSession {
     this.volume = 50;
     this.volumeSupported = false;
     this.transportState = '';
+    this.pendingStartSec = -1;
+    this.relTimeUnavailable = false;
+    this.needRelTimeToast = false;
+    this.originMs = 0;
+    this.terminal = false;
     this.resetHealthCounters();
+    this.setPhase(CastPhase.IDLE);
   }
 
-  startPoll(intervalMs: number = 2000): void {
+  setHudPolling(on: boolean): void {
+    this.hudPolling = on;
+    if (this.device) {
+      this.startPoll(this.pollInterval());
+    }
+  }
+
+  startPoll(intervalMs: number = CastSession.BG_POLL_MS): void {
     this.stopPoll();
     if (!this.device || !this.device.controlURL) {
       return;
     }
     this.pollToken += 1;
     const token: number = this.pollToken;
-    this.tickOnce(token);
+    this.poller.tickOnce(this, token);
     this.pollTimer = setInterval(() => {
-      this.tickOnce(token);
+      this.poller.tickOnce(this, token);
     }, intervalMs) as number;
   }
 
@@ -98,16 +142,63 @@ export class CastSession {
       this.volume = await this.client.getVolume(device);
       this.volumeSupported = true;
     } catch (err) {
-      console.error(`[CastSession] GetVolume fail: ${JSON.stringify(err)}`);
+      console.error(`${CastSession.TAG} GetVolume fail: ${JSON.stringify(err)}`);
       this.volumeSupported = false;
     }
   }
 
-  /**
-   * Send Stop to the renderer and clear local state.
-   * Only call on explicit user Stop or true leave of PlayPage.
-   */
+  async setVolume(pct: number): Promise<void> {
+    const device: DlnaDevice | null = this.device;
+    if (!device || !device.renderingControlURL) {
+      return;
+    }
+    await this.client.setVolume(device, pct);
+  }
+
+  async play(): Promise<void> {
+    const device: DlnaDevice | null = this.device;
+    if (!device) {
+      return;
+    }
+    await this.client.play(device);
+    this.transportState = 'PLAYING';
+    this.originMs = Date.now() - Math.max(0, this.positionSec) * 1000;
+    this.setPhase(CastPhase.PLAYING);
+    this.emitState();
+  }
+
+  async pause(): Promise<void> {
+    const device: DlnaDevice | null = this.device;
+    if (!device) {
+      return;
+    }
+    await this.client.pause(device);
+    this.transportState = 'PAUSED_PLAYBACK';
+    this.originMs = 0;
+    this.setPhase(CastPhase.PAUSED);
+    this.emitState();
+  }
+
+  async seek(positionSec: number): Promise<void> {
+    const device: DlnaDevice | null = this.device;
+    if (!device) {
+      return;
+    }
+    const target: number = this.durationSec > 0 ?
+      Math.max(0, Math.min(positionSec, this.durationSec)) : Math.max(0, positionSec);
+    await this.client.seek(device, target);
+    this.pendingStartSec = -1;
+    this.positionSec = target;
+    this.originMs = Date.now() - target * 1000;
+    this.emitState();
+  }
+
+  /** Unique Stop SOAP entry. */
   async stopRemote(): Promise<void> {
+    if (this.phase === CastPhase.STOPPING) {
+      return;
+    }
+    this.setPhase(CastPhase.STOPPING);
     const device: DlnaDevice | null = this.device;
     this.clearLocal();
     if (!device) {
@@ -116,127 +207,75 @@ export class CastSession {
     try {
       await this.client.stop(device);
     } catch (err) {
-      console.error(`[CastSession] stop failed: ${JSON.stringify(err)}`);
+      console.error(`${CastSession.TAG} stop failed: ${JSON.stringify(err)}`);
     }
   }
 
-  /** Reset fail/STOPPED counters (e.g. after successful cast attach). */
-  resetHealthCounters(): void {
-    this.everPlayed = false;
-    this.stoppedStreak = 0;
-    this.failStreak = 0;
-  }
-
-  /** Reset fail streak after a successful position/transport poll. */
-  notePollSuccess(): void {
-    this.failStreak = 0;
-  }
-
-  /**
-   * Record a failed GetPositionInfo / GetTransportInfo tick while session active.
-   * @returns true if remote disconnect was triggered (clearLocal already ran).
-   */
-  notePollFailure(): boolean {
-    if (!this.device) {
-      return false;
-    }
-    this.failStreak += 1;
-    if (this.failStreak >= CastSession.FAIL_THRESHOLD) {
-      console.info(`[CastSession] remote disconnect: poll fail x${this.failStreak}`);
-      this.handleRemoteDisconnect();
-      return true;
-    }
-    return false;
-  }
-
-  /**
-   * Observe CurrentTransportState from GetTransportInfo (or sheet poll).
-   * STOPPED / NO_MEDIA_PRESENT for N polls after ever PLAYING/TRANSITIONING → disconnect.
-   * @returns true if remote disconnect was triggered (clearLocal already ran).
-   */
-  noteTransportState(state: string): boolean {
-    this.transportState = state ? state : '';
-    const upper: string = (state || '').toUpperCase();
-    if (upper === 'PLAYING' || upper === 'TRANSITIONING') {
-      this.everPlayed = true;
-      this.stoppedStreak = 0;
-      this.failStreak = 0;
-      return false;
-    }
-    if (!this.device || !this.everPlayed) {
-      this.stoppedStreak = 0;
-      return false;
-    }
-    if (upper === 'STOPPED' || upper === 'NO_MEDIA_PRESENT') {
-      this.stoppedStreak += 1;
-      if (this.stoppedStreak >= CastSession.STOPPED_THRESHOLD) {
-        console.info(`[CastSession] remote disconnect: ${upper} x${this.stoppedStreak}`);
-        this.handleRemoteDisconnect();
-        return true;
-      }
-      return false;
-    }
-    // PAUSED_PLAYBACK and other states: not a remote stop.
-    this.stoppedStreak = 0;
-    return false;
-  }
-
-  private handleRemoteDisconnect(): void {
-    const pos: number = this.positionSec;
-    const cb: ((positionSec: number) => void) | null = this.onRemoteDisconnected;
-    this.clearLocal();
-    if (cb) {
-      cb(pos);
-    }
-  }
-
-  private async tickOnce(token: number): Promise<void> {
-    if (token !== this.pollToken) {
-      return;
-    }
+  async replaceUri(url: string, title: string, startSec: number): Promise<void> {
     const device: DlnaDevice | null = this.device;
     if (!device || !device.controlURL) {
-      return;
+      throw new Error('投屏设备已断开');
     }
-
-    let positionOk: boolean = false;
-    let transportOk: boolean = false;
-
+    this.stopPoll();
     try {
-      const info: DlnaPositionInfo = await this.client.getPositionInfo(device);
-      if (token !== this.pollToken) {
-        return;
-      }
-      positionOk = true;
-      this.positionSec = info.positionSec;
-      if (info.durationSec > 0) {
-        this.durationSec = info.durationSec;
-      }
-    } catch (err) {
-      console.error(`[CastSession] GetPositionInfo fail: ${JSON.stringify(err)}`);
-    }
-
-    try {
-      const state: string = await this.client.getTransportInfo(device);
-      if (token !== this.pollToken) {
-        return;
-      }
-      transportOk = true;
-      if (this.noteTransportState(state)) {
-        return;
-      }
+      await this.client.stop(device);
     } catch (_e) {
-      // Optional; counted toward fail streak with position below.
     }
+    this.positionSec = startSec;
+    this.durationSec = 0;
+    this.pendingStartSec = startSec >= 2 ? startSec : -1;
+    this.relTimeUnavailable = false;
+    this.needRelTimeToast = false;
+    this.relNiStreak = 0;
+    this.originMs = 0;
+    this.startSeekTries = 0;
+    this.startSeeking = false;
+    this.terminal = false;
+    this.resetHealthCounters();
+    this.transportState = '';
+    this.launchAtMs = Date.now();
+    this.timeoutMs = CastSession.matchSlow(device) ? CastSession.SLOW_MS : CastSession.FAST_MS;
+    this.setPhase(CastPhase.LAUNCHING);
+    this.emitState();
+    await this.client.cast(device, url, title, startSec, 0);
+    this.startPoll(this.pollInterval());
+  }
 
-    if (token !== this.pollToken || !this.device) {
+  confirmed(): boolean {
+    return this.phase === CastPhase.PLAYING || this.phase === CastPhase.PAUSED;
+  }
+
+  setPhase(next: string): void {
+    if (this.phase === next) {
       return;
     }
+    console.info(`${CastSession.TAG} phase ${this.phase} -> ${next}`);
+    this.phase = next;
+  }
 
-    if (positionOk || transportOk) {
-      this.notePollSuccess();
-    } else if (this.notePollFailure()) {
-      return;
+  emitState(): void {
+    if (this.onState) {
+      this.onState();
     }
+  }
+
+  private resetHealthCounters(): void {
+    this.stoppedStreak = 0;
+    this.failStreak = 0;
+    this.eosStopStreak = 0;
+  }
+
+  private pollInterval(): number {
+    return this.hudPolling ? CastSession.HUD_POLL_MS : CastSession.BG_POLL_MS;
+  }
+
+  private static matchSlow(device: DlnaDevice): boolean {
+    const blob: string = `${device.manufacturer} ${device.friendlyName}`.toLowerCase();
+    for (let i = 0; i < CastSession.SLOW_NAME_SUBSTR.length; i++) {
+      if (blob.indexOf(CastSession.SLOW_NAME_SUBSTR[i]) >= 0) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/entry/src/main/ets/common/utils/CastSession.ets
+++ b/entry/src/main/ets/common/utils/CastSession.ets
@@ -6,6 +6,9 @@ import { DlnaDevice, DlnaPositionInfo } from './DlnaTypes';
  * Keeps device state + optional background GetPositionInfo poll so
  * screen-off / brief background does not tear down TV playback, and
  * progress stays fresh when the sheet reopens.
+ *
+ * Also watches transport / poll health: when the TV stops or drops off
+ * the network, clearLocal() only (never Stop SOAP) and notify UI.
  */
 export class CastSession {
   device: DlnaDevice | null = null;
@@ -15,9 +18,22 @@ export class CastSession {
   volumeSupported: boolean = false;
   transportState: string = '';
 
+  /** Fired after clearLocal on remote STOPPED / poll-fail disconnect. */
+  onRemoteDisconnected: (() => void) | null = null;
+
   private client: DlnaClient = new DlnaClient();
   private pollTimer: number = -1;
   private pollToken: number = 0;
+
+  /** True once we have seen PLAYING or TRANSITIONING after attach. */
+  private everPlayed: boolean = false;
+  private stoppedStreak: number = 0;
+  private failStreak: number = 0;
+
+  /** Consecutive STOPPED / NO_MEDIA_PRESENT polls after everPlayed. */
+  private static readonly STOPPED_THRESHOLD: number = 3;
+  /** Consecutive failed GetPositionInfo+GetTransportInfo polls while active. */
+  private static readonly FAIL_THRESHOLD: number = 3;
 
   get active(): boolean {
     return this.device !== null;
@@ -36,6 +52,7 @@ export class CastSession {
     this.positionSec = 0;
     this.durationSec = 0;
     this.transportState = '';
+    this.resetHealthCounters();
   }
 
   /** Clear local session state without sending Stop to the renderer. */
@@ -47,6 +64,7 @@ export class CastSession {
     this.volume = 50;
     this.volumeSupported = false;
     this.transportState = '';
+    this.resetHealthCounters();
   }
 
   startPoll(intervalMs: number = 2000): void {
@@ -102,6 +120,75 @@ export class CastSession {
     }
   }
 
+  /** Reset fail/STOPPED counters (e.g. after successful cast attach). */
+  resetHealthCounters(): void {
+    this.everPlayed = false;
+    this.stoppedStreak = 0;
+    this.failStreak = 0;
+  }
+
+  /** Reset fail streak after a successful position/transport poll. */
+  notePollSuccess(): void {
+    this.failStreak = 0;
+  }
+
+  /**
+   * Record a failed GetPositionInfo / GetTransportInfo tick while session active.
+   * @returns true if remote disconnect was triggered (clearLocal already ran).
+   */
+  notePollFailure(): boolean {
+    if (!this.device) {
+      return false;
+    }
+    this.failStreak += 1;
+    if (this.failStreak >= CastSession.FAIL_THRESHOLD) {
+      console.info(`[CastSession] remote disconnect: poll fail x${this.failStreak}`);
+      this.handleRemoteDisconnect();
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Observe CurrentTransportState from GetTransportInfo (or sheet poll).
+   * STOPPED / NO_MEDIA_PRESENT for N polls after ever PLAYING/TRANSITIONING → disconnect.
+   * @returns true if remote disconnect was triggered (clearLocal already ran).
+   */
+  noteTransportState(state: string): boolean {
+    this.transportState = state ? state : '';
+    const upper: string = (state || '').toUpperCase();
+    if (upper === 'PLAYING' || upper === 'TRANSITIONING') {
+      this.everPlayed = true;
+      this.stoppedStreak = 0;
+      this.failStreak = 0;
+      return false;
+    }
+    if (!this.device || !this.everPlayed) {
+      this.stoppedStreak = 0;
+      return false;
+    }
+    if (upper === 'STOPPED' || upper === 'NO_MEDIA_PRESENT') {
+      this.stoppedStreak += 1;
+      if (this.stoppedStreak >= CastSession.STOPPED_THRESHOLD) {
+        console.info(`[CastSession] remote disconnect: ${upper} x${this.stoppedStreak}`);
+        this.handleRemoteDisconnect();
+        return true;
+      }
+      return false;
+    }
+    // PAUSED_PLAYBACK and other states: not a remote stop.
+    this.stoppedStreak = 0;
+    return false;
+  }
+
+  private handleRemoteDisconnect(): void {
+    const cb: (() => void) | null = this.onRemoteDisconnected;
+    this.clearLocal();
+    if (cb) {
+      cb();
+    }
+  }
+
   private async tickOnce(token: number): Promise<void> {
     if (token !== this.pollToken) {
       return;
@@ -110,11 +197,16 @@ export class CastSession {
     if (!device || !device.controlURL) {
       return;
     }
+
+    let positionOk: boolean = false;
+    let transportOk: boolean = false;
+
     try {
       const info: DlnaPositionInfo = await this.client.getPositionInfo(device);
       if (token !== this.pollToken) {
         return;
       }
+      positionOk = true;
       this.positionSec = info.positionSec;
       if (info.durationSec > 0) {
         this.durationSec = info.durationSec;
@@ -122,14 +214,28 @@ export class CastSession {
     } catch (err) {
       console.error(`[CastSession] GetPositionInfo fail: ${JSON.stringify(err)}`);
     }
+
     try {
       const state: string = await this.client.getTransportInfo(device);
       if (token !== this.pollToken) {
         return;
       }
-      this.transportState = state;
+      transportOk = true;
+      if (this.noteTransportState(state)) {
+        return;
+      }
     } catch (_e) {
-      // Optional.
+      // Optional; counted toward fail streak with position below.
+    }
+
+    if (token !== this.pollToken || !this.device) {
+      return;
+    }
+
+    if (positionOk || transportOk) {
+      this.notePollSuccess();
+    } else if (this.notePollFailure()) {
+      return;
     }
   }
 }

--- a/entry/src/main/ets/common/utils/CastSession.ets
+++ b/entry/src/main/ets/common/utils/CastSession.ets
@@ -18,8 +18,8 @@ export class CastSession {
   volumeSupported: boolean = false;
   transportState: string = '';
 
-  /** Fired after clearLocal on remote STOPPED / poll-fail disconnect. */
-  onRemoteDisconnected: (() => void) | null = null;
+  /** Fired after clearLocal on remote STOPPED / poll-fail disconnect. Position is the last known TV time. */
+  onRemoteDisconnected: ((positionSec: number) => void) | null = null;
 
   private client: DlnaClient = new DlnaClient();
   private pollTimer: number = -1;
@@ -182,10 +182,11 @@ export class CastSession {
   }
 
   private handleRemoteDisconnect(): void {
-    const cb: (() => void) | null = this.onRemoteDisconnected;
+    const pos: number = this.positionSec;
+    const cb: ((positionSec: number) => void) | null = this.onRemoteDisconnected;
     this.clearLocal();
     if (cb) {
-      cb();
+      cb(pos);
     }
   }
 

--- a/entry/src/main/ets/common/utils/CastSession.ets
+++ b/entry/src/main/ets/common/utils/CastSession.ets
@@ -1,0 +1,135 @@
+import { DlnaClient } from './DlnaClient';
+import { DlnaDevice, DlnaPositionInfo } from './DlnaTypes';
+
+/**
+ * Lightweight cast session that outlives the cast dialog.
+ * Keeps device state + optional background GetPositionInfo poll so
+ * screen-off / brief background does not tear down TV playback, and
+ * progress stays fresh when the sheet reopens.
+ */
+export class CastSession {
+  device: DlnaDevice | null = null;
+  positionSec: number = 0;
+  durationSec: number = 0;
+  volume: number = 50;
+  volumeSupported: boolean = false;
+  transportState: string = '';
+
+  private client: DlnaClient = new DlnaClient();
+  private pollTimer: number = -1;
+  private pollToken: number = 0;
+
+  get active(): boolean {
+    return this.device !== null;
+  }
+
+  get usn(): string {
+    return this.device ? this.device.usn : '';
+  }
+
+  get deviceName(): string {
+    return this.device ? this.device.friendlyName : '';
+  }
+
+  attach(device: DlnaDevice): void {
+    this.device = device;
+    this.positionSec = 0;
+    this.durationSec = 0;
+    this.transportState = '';
+  }
+
+  /** Clear local session state without sending Stop to the renderer. */
+  clearLocal(): void {
+    this.stopPoll();
+    this.device = null;
+    this.positionSec = 0;
+    this.durationSec = 0;
+    this.volume = 50;
+    this.volumeSupported = false;
+    this.transportState = '';
+  }
+
+  startPoll(intervalMs: number = 2000): void {
+    this.stopPoll();
+    if (!this.device || !this.device.controlURL) {
+      return;
+    }
+    this.pollToken += 1;
+    const token: number = this.pollToken;
+    this.tickOnce(token);
+    this.pollTimer = setInterval(() => {
+      this.tickOnce(token);
+    }, intervalMs) as number;
+  }
+
+  stopPoll(): void {
+    this.pollToken += 1;
+    if (this.pollTimer >= 0) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = -1;
+    }
+  }
+
+  async refreshVolume(): Promise<void> {
+    const device: DlnaDevice | null = this.device;
+    if (!device || !device.renderingControlURL) {
+      this.volumeSupported = false;
+      return;
+    }
+    try {
+      this.volume = await this.client.getVolume(device);
+      this.volumeSupported = true;
+    } catch (err) {
+      console.error(`[CastSession] GetVolume fail: ${JSON.stringify(err)}`);
+      this.volumeSupported = false;
+    }
+  }
+
+  /**
+   * Send Stop to the renderer and clear local state.
+   * Only call on explicit user Stop or true leave of PlayPage.
+   */
+  async stopRemote(): Promise<void> {
+    const device: DlnaDevice | null = this.device;
+    this.clearLocal();
+    if (!device) {
+      return;
+    }
+    try {
+      await this.client.stop(device);
+    } catch (err) {
+      console.error(`[CastSession] stop failed: ${JSON.stringify(err)}`);
+    }
+  }
+
+  private async tickOnce(token: number): Promise<void> {
+    if (token !== this.pollToken) {
+      return;
+    }
+    const device: DlnaDevice | null = this.device;
+    if (!device || !device.controlURL) {
+      return;
+    }
+    try {
+      const info: DlnaPositionInfo = await this.client.getPositionInfo(device);
+      if (token !== this.pollToken) {
+        return;
+      }
+      this.positionSec = info.positionSec;
+      if (info.durationSec > 0) {
+        this.durationSec = info.durationSec;
+      }
+    } catch (err) {
+      console.error(`[CastSession] GetPositionInfo fail: ${JSON.stringify(err)}`);
+    }
+    try {
+      const state: string = await this.client.getTransportInfo(device);
+      if (token !== this.pollToken) {
+        return;
+      }
+      this.transportState = state;
+    } catch (_e) {
+      // Optional.
+    }
+  }
+}

--- a/entry/src/main/ets/common/utils/CastSessionPoll.ets
+++ b/entry/src/main/ets/common/utils/CastSessionPoll.ets
@@ -1,0 +1,282 @@
+import { DlnaClient } from './DlnaClient';
+import { CastPhase, DlnaDevice, DlnaPositionInfo, isRelTimeUnavailable } from './DlnaTypes';
+
+/** Session surface used by the poll tick. Avoids a circular import. */
+export interface CastPollHost {
+  device: DlnaDevice | null;
+  positionSec: number;
+  durationSec: number;
+  transportState: string;
+  phase: string;
+  relTimeUnavailable: boolean;
+  needRelTimeToast: boolean;
+  pendingStartSec: number;
+  onFailed: ((positionSec: number) => void) | null;
+  onCompleted: (() => void) | null;
+  onDisconnected: ((positionSec: number) => void) | null;
+  client: DlnaClient;
+  pollToken: number;
+  pollBusy: boolean;
+  terminal: boolean;
+  failStreak: number;
+  relNiStreak: number;
+  originMs: number;
+  launchAtMs: number;
+  timeoutMs: number;
+  stoppedStreak: number;
+  eosStopStreak: number;
+  startSeekTries: number;
+  startSeeking: boolean;
+  confirmed(): boolean;
+  setPhase(next: string): void;
+  emitState(): void;
+  stopPoll(): void;
+  clearLocal(): void;
+  stopRemote(): Promise<void>;
+}
+
+/** GetTransportInfo + GetPositionInfo tick: launch confirm, EOS, disconnect. */
+export class CastSessionPoll {
+  private static readonly TAG: string = '[CastSession]';
+  private static readonly FAIL_THRESHOLD: number = 3;
+  private static readonly STOPPED_DISCONNECT: number = 3;
+  private static readonly EOS_STOP_TICKS: number = 2;
+  private static readonly REL_NI_TICKS: number = 3;
+  private static readonly START_SEEK_MAX: number = 8;
+
+  async tickOnce(s: CastPollHost, token: number): Promise<void> {
+    if (token !== s.pollToken || s.pollBusy || s.terminal) {
+      return;
+    }
+    s.pollBusy = true;
+    try {
+      await this.pollTickBody(s, token);
+    } finally {
+      s.pollBusy = false;
+    }
+  }
+
+  private async pollTickBody(s: CastPollHost, token: number): Promise<void> {
+    if (token !== s.pollToken) {
+      return;
+    }
+    const device: DlnaDevice | null = s.device;
+    if (!device || !device.controlURL) {
+      return;
+    }
+    let positionOk: boolean = false;
+    let transportOk: boolean = false;
+    try {
+      const info: DlnaPositionInfo = await s.client.getPositionInfo(device);
+      if (token !== s.pollToken) {
+        return;
+      }
+      positionOk = true;
+      this.applyPosition(s, info);
+    } catch (err) {
+      console.error(`${CastSessionPoll.TAG} GetPositionInfo fail: ${JSON.stringify(err)}`);
+    }
+    try {
+      const state: string = await s.client.getTransportInfo(device);
+      if (token !== s.pollToken) {
+        return;
+      }
+      transportOk = true;
+      s.transportState = state ? state : '';
+    } catch (_e) {
+    }
+    if (token !== s.pollToken || !s.device) {
+      return;
+    }
+    if (positionOk || transportOk) {
+      s.failStreak = 0;
+    } else {
+      s.failStreak += 1;
+      if (s.confirmed() && s.failStreak >= CastSessionPoll.FAIL_THRESHOLD) {
+        this.disconnectRemote(s, `poll fail x${s.failStreak}`);
+        return;
+      }
+    }
+    this.judgeTick(s);
+    if (s.device && s.confirmed()) {
+      this.applyPendingStart(s, device);
+    }
+    s.emitState();
+  }
+
+  private applyPosition(s: CastPollHost, info: DlnaPositionInfo): void {
+    if (isRelTimeUnavailable(info.relTime)) {
+      s.relNiStreak += 1;
+      if (s.relNiStreak >= CastSessionPoll.REL_NI_TICKS && !s.relTimeUnavailable) {
+        s.relTimeUnavailable = true;
+        s.needRelTimeToast = true;
+        console.info(`${CastSessionPoll.TAG} RelTime unavailable`);
+      }
+    } else {
+      s.relNiStreak = 0;
+    }
+    if (info.durationSec > 0) {
+      s.durationSec = info.durationSec;
+    }
+    const upper: string = (s.transportState || '').toUpperCase();
+    if (s.pendingStartSec >= 2) {
+      if (info.positionSec > 0 && Math.abs(info.positionSec - s.pendingStartSec) <= 8) {
+        s.pendingStartSec = -1;
+        s.positionSec = info.positionSec;
+        s.originMs = Date.now() - info.positionSec * 1000;
+      } else {
+        s.positionSec = s.pendingStartSec;
+      }
+      return;
+    }
+    if (!s.relTimeUnavailable && info.positionSec > 0) {
+      s.positionSec = info.positionSec;
+      s.originMs = Date.now() - info.positionSec * 1000;
+      return;
+    }
+    if (s.confirmed() && upper === 'PLAYING') {
+      if (s.originMs <= 0) {
+        s.originMs = Date.now() - Math.max(0, s.positionSec) * 1000;
+      }
+      let est: number = (Date.now() - s.originMs) / 1000;
+      if (s.durationSec > 1) {
+        est = Math.min(est, s.durationSec);
+      }
+      s.positionSec = Math.max(0, est);
+    }
+  }
+
+  private judgeTick(s: CastPollHost): void {
+    if (s.terminal) {
+      return;
+    }
+    const upper: string = (s.transportState || '').toUpperCase();
+    if (upper === 'ERROR') {
+      this.failLaunch(s, 'ERROR');
+      return;
+    }
+    if (s.phase === CastPhase.LAUNCHING) {
+      this.judgeLaunching(s, upper);
+      return;
+    }
+    if (!s.confirmed()) {
+      return;
+    }
+    if (this.isEosCandidate(s, upper)) {
+      s.eosStopStreak += 1;
+      s.stoppedStreak = 0;
+      if (s.eosStopStreak >= CastSessionPoll.EOS_STOP_TICKS) {
+        this.completeCurrent(s);
+      }
+      return;
+    }
+    s.eosStopStreak = 0;
+    if (upper === 'STOPPED' || upper === 'NO_MEDIA_PRESENT') {
+      s.stoppedStreak += 1;
+      if (s.stoppedStreak >= CastSessionPoll.STOPPED_DISCONNECT) {
+        this.disconnectRemote(s, `${upper} x${s.stoppedStreak}`);
+      }
+      return;
+    }
+    s.stoppedStreak = 0;
+    if (upper === 'PAUSED_PLAYBACK') {
+      s.setPhase(CastPhase.PAUSED);
+    } else if (upper === 'PLAYING') {
+      s.setPhase(CastPhase.PLAYING);
+    }
+  }
+
+  private judgeLaunching(s: CastPollHost, upper: string): void {
+    const relOk: boolean = !s.relTimeUnavailable && s.positionSec > 0;
+    const playLike: boolean = upper === 'PLAYING' || upper === 'PAUSED_PLAYBACK';
+    if (playLike || relOk) {
+      s.setPhase(upper === 'PAUSED_PLAYBACK' ? CastPhase.PAUSED : CastPhase.PLAYING);
+      s.stoppedStreak = 0;
+      s.failStreak = 0;
+      s.eosStopStreak = 0;
+      console.info(`${CastSessionPoll.TAG} launch confirmed state=${upper} pos=${s.positionSec}`);
+      return;
+    }
+    if (Date.now() - s.launchAtMs >= s.timeoutMs) {
+      this.failLaunch(s, 'timeout');
+    }
+  }
+
+  private isEosCandidate(s: CastPollHost, upper: string): boolean {
+    if (!s.confirmed() || s.relTimeUnavailable) {
+      return false;
+    }
+    if (s.durationSec <= 1 || s.positionSec < s.durationSec - 3) {
+      return false;
+    }
+    return upper === 'STOPPED' || upper === 'NO_MEDIA_PRESENT';
+  }
+
+  private completeCurrent(s: CastPollHost): void {
+    if (s.terminal) {
+      return;
+    }
+    s.terminal = true;
+    s.stopPoll();
+    s.setPhase(CastPhase.COMPLETED);
+    console.info(`${CastSessionPoll.TAG} completed pos=${s.positionSec} dur=${s.durationSec}`);
+    s.emitState();
+    if (s.onCompleted) {
+      s.onCompleted();
+    }
+  }
+
+  private disconnectRemote(s: CastPollHost, reason: string): void {
+    if (s.terminal || !s.device) {
+      return;
+    }
+    s.terminal = true;
+    const pos: number = s.positionSec;
+    const cb: ((positionSec: number) => void) | null = s.onDisconnected;
+    console.info(`${CastSessionPoll.TAG} disconnected: ${reason} pos=${pos}`);
+    s.setPhase(CastPhase.DISCONNECTED);
+    s.clearLocal();
+    if (cb) {
+      cb(pos);
+    }
+  }
+
+  private async failLaunch(s: CastPollHost, reason: string): Promise<void> {
+    if (s.terminal || s.phase === CastPhase.FAILED || s.phase === CastPhase.STOPPING) {
+      return;
+    }
+    s.terminal = true;
+    console.info(`${CastSessionPoll.TAG} failed: ${reason}`);
+    s.setPhase(CastPhase.FAILED);
+    const pos: number = s.positionSec;
+    const cb: ((positionSec: number) => void) | null = s.onFailed;
+    await s.stopRemote();
+    if (cb) {
+      cb(pos);
+    }
+  }
+
+  private applyPendingStart(s: CastPollHost, device: DlnaDevice): void {
+    if (s.pendingStartSec < 2 || s.startSeeking || s.startSeekTries >= CastSessionPoll.START_SEEK_MAX) {
+      return;
+    }
+    const waited: number = Date.now() - s.launchAtMs;
+    if (s.durationSec <= 1 && waited < 2500) {
+      return;
+    }
+    const target: number = s.durationSec > 1 ?
+      Math.min(s.pendingStartSec, Math.max(0, s.durationSec - 1)) : s.pendingStartSec;
+    s.startSeeking = true;
+    s.startSeekTries += 1;
+    console.info(`${CastSessionPoll.TAG} resume seek try=${s.startSeekTries} target=${target}`);
+    s.client.seek(device, target).then(() => {
+      s.startSeeking = false;
+    }).catch((err: Object) => {
+      s.startSeeking = false;
+      console.error(`${CastSessionPoll.TAG} resume seek fail: ${JSON.stringify(err)}`);
+      if (s.startSeekTries >= CastSessionPoll.START_SEEK_MAX) {
+        s.pendingStartSec = -1;
+      }
+    });
+  }
+}

--- a/entry/src/main/ets/common/utils/CastSessionPoll.ets
+++ b/entry/src/main/ets/common/utils/CastSessionPoll.ets
@@ -187,7 +187,9 @@ export class CastSessionPoll {
   }
 
   private judgeLaunching(s: CastPollHost, upper: string): void {
-    const relOk: boolean = !s.relTimeUnavailable && s.positionSec > 0;
+    // RelTime side-signal only after pending resume seek is cleared — never treat
+    // positionSec=pendingStartSec as device RelTime evidence (would false-confirm).
+    const relOk: boolean = !s.relTimeUnavailable && s.pendingStartSec < 2 && s.positionSec > 0;
     const playLike: boolean = upper === 'PLAYING' || upper === 'PAUSED_PLAYBACK';
     if (playLike || relOk) {
       s.setPhase(upper === 'PAUSED_PLAYBACK' ? CastPhase.PAUSED : CastPhase.PLAYING);

--- a/entry/src/main/ets/common/utils/DlnaClient.ets
+++ b/entry/src/main/ets/common/utils/DlnaClient.ets
@@ -1,6 +1,6 @@
 import { http, socket } from '@kit.NetworkKit';
 import { BusinessError } from '@kit.BasicServicesKit';
-import { DlnaDevice, DlnaPositionInfo } from './DlnaTypes';
+import { DlnaDevice, DlnaPositionInfo, DlnaSoapError } from './DlnaTypes';
 
 interface SsdpMessageInfo {
   message: ArrayBuffer;
@@ -410,8 +410,10 @@ export class DlnaClient {
       const code: number = response.responseCode;
       const resultText: string = typeof response.result === 'string' ? response.result : '';
       if (code < 200 || code >= 300 || /<\w*:?Fault[\s>]/i.test(resultText)) {
-        console.error(`${DlnaClient.TAG} SOAP ${action} HTTP ${code}: ${resultText.substring(0, 200)}`);
-        throw new Error(`投屏指令失败 (${action}, HTTP ${code})`);
+        const soap: DlnaSoapError = this.buildSoapError(action, code, resultText);
+        console.error(`${DlnaClient.TAG} SOAP ${action} HTTP ${code} errorCode=${soap.errorCode}: ` +
+          `${resultText.substring(0, 200)}`);
+        throw new Error(soap.message);
       }
       console.info(`${DlnaClient.TAG} SOAP ${action} ok`);
       return resultText;
@@ -515,6 +517,23 @@ export class DlnaClient {
       }
     }
     return '';
+  }
+
+  private buildSoapError(action: string, httpCode: number, body: string): DlnaSoapError {
+    const err: DlnaSoapError = new DlnaSoapError();
+    err.action = action;
+    err.httpCode = httpCode;
+    const codeRaw: string = this.extractTag(body, 'errorCode');
+    const parsed: number = parseInt(codeRaw, 10);
+    err.errorCode = isNaN(parsed) ? 0 : parsed;
+    err.errorDescription = this.extractTag(body, 'errorDescription');
+    const codePart: string = err.errorCode > 0 ? `${err.errorCode}` : `HTTP ${httpCode}`;
+    if (err.errorDescription) {
+      err.message = `${err.errorDescription} (${action}, ${codePart})`;
+    } else {
+      err.message = `投屏指令失败 (${action}, ${codePart})`;
+    }
+    return err;
   }
 
   private extractTag(xml: string, tag: string): string {
@@ -676,6 +695,7 @@ export class DlnaClient {
           family: 1
         };
         this.multicast.dropMembership(addr).catch(() => {});
+        this.multicast.close();
       } catch (_e) {
       }
       this.multicast = null;

--- a/entry/src/main/ets/common/utils/DlnaClient.ets
+++ b/entry/src/main/ets/common/utils/DlnaClient.ets
@@ -66,14 +66,37 @@ export class DlnaClient {
     this.closeSockets();
   }
 
-  public async cast(device: DlnaDevice, mediaUrl: string, title: string = 'EcoHub'): Promise<void> {
+  public async cast(device: DlnaDevice, mediaUrl: string, title: string = 'EcoHub',
+    startSec: number = 0, durationSec: number = 0): Promise<void> {
     if (!mediaUrl) {
       throw new Error('当前没有可投屏的地址');
     }
-    console.info(`${DlnaClient.TAG} cast -> ${device.friendlyName} ${device.controlURL}`);
+    console.info(`${DlnaClient.TAG} cast -> ${device.friendlyName} start=${startSec} dur=${durationSec}`);
     await this.soapAction(device.controlURL, DlnaClient.AVT, 'SetAVTransportURI',
-      this.buildSetUriBody(mediaUrl, title));
+      this.buildSetUriBody(mediaUrl, title, durationSec));
+    // One REL_TIME try while STOPPED. Do not run padded/ABS fallbacks here — those extra
+    // Faults would stall the picker. HUD retries after TrackDuration is known.
+    if (startSec >= 2) {
+      try {
+        const hms: string = DlnaClient.formatRelTime(startSec);
+        console.info(`${DlnaClient.TAG} pre-play seek REL_TIME ${hms}`);
+        await this.soapAction(device.controlURL, DlnaClient.AVT, 'Seek',
+          this.buildSeekBody(hms, 'REL_TIME'));
+      } catch (err) {
+        console.info(`${DlnaClient.TAG} pre-play seek ignored: ${JSON.stringify(err)}`);
+      }
+    }
+    await this.play(device);
+  }
+
+  public async play(device: DlnaDevice): Promise<void> {
+    console.info(`${DlnaClient.TAG} play -> ${device.friendlyName}`);
     await this.soapAction(device.controlURL, DlnaClient.AVT, 'Play', this.buildPlayBody());
+  }
+
+  public async pause(device: DlnaDevice): Promise<void> {
+    console.info(`${DlnaClient.TAG} pause -> ${device.friendlyName}`);
+    await this.soapAction(device.controlURL, DlnaClient.AVT, 'Pause', this.buildPauseBody());
   }
 
   public async stop(device: DlnaDevice): Promise<void> {
@@ -82,19 +105,40 @@ export class DlnaClient {
   }
 
   public async seek(device: DlnaDevice, positionSec: number): Promise<void> {
-    const target: string = DlnaClient.formatRelTime(positionSec);
-    console.info(`${DlnaClient.TAG} seek -> ${device.friendlyName} ${target}`);
-    await this.soapAction(device.controlURL, DlnaClient.AVT, 'Seek', this.buildSeekBody(target));
+    const hms: string = DlnaClient.formatRelTime(positionSec);
+    const padded: string = DlnaClient.formatRelTimePadded(positionSec);
+    try {
+      console.info(`${DlnaClient.TAG} seek REL_TIME -> ${device.friendlyName} ${hms}`);
+      await this.soapAction(device.controlURL, DlnaClient.AVT, 'Seek', this.buildSeekBody(hms, 'REL_TIME'));
+      return;
+    } catch (_rel) {
+      try {
+        console.info(`${DlnaClient.TAG} seek REL_TIME padded -> ${device.friendlyName} ${padded}`);
+        await this.soapAction(device.controlURL, DlnaClient.AVT, 'Seek', this.buildSeekBody(padded, 'REL_TIME'));
+        return;
+      } catch (_pad) {
+        console.info(`${DlnaClient.TAG} seek ABS_TIME -> ${device.friendlyName} ${hms}`);
+        await this.soapAction(device.controlURL, DlnaClient.AVT, 'Seek', this.buildSeekBody(hms, 'ABS_TIME'));
+      }
+    }
   }
 
   public async getPositionInfo(device: DlnaDevice): Promise<DlnaPositionInfo> {
     const xml: string = await this.soapAction(device.controlURL, DlnaClient.AVT, 'GetPositionInfo',
       this.buildGetPositionInfoBody());
     const relTime: string = this.extractTag(xml, 'RelTime');
-    const trackDuration: string = this.extractTag(xml, 'TrackDuration');
+    let trackDuration: string = this.extractTag(xml, 'TrackDuration');
+    let durationSec: number = DlnaClient.parseRelTime(trackDuration);
+    if (durationSec <= 0) {
+      const fromMeta: string = this.extractAttr(xml, 'duration');
+      if (fromMeta) {
+        trackDuration = fromMeta;
+        durationSec = DlnaClient.parseRelTime(fromMeta);
+      }
+    }
     return {
       positionSec: DlnaClient.parseRelTime(relTime),
-      durationSec: DlnaClient.parseRelTime(trackDuration),
+      durationSec: durationSec,
       relTime: relTime,
       trackDuration: trackDuration
     };
@@ -136,7 +180,8 @@ export class DlnaClient {
       return 0;
     }
     const trimmed: string = value.trim();
-    if (!trimmed || trimmed === 'NOT_IMPLEMENTED' || trimmed.indexOf(':') < 0) {
+    if (!trimmed || trimmed === 'NOT_IMPLEMENTED' || trimmed === '*' || trimmed === '-' ||
+      trimmed.indexOf(':') < 0) {
       return 0;
     }
     const parts: string[] = trimmed.split(':');
@@ -160,16 +205,27 @@ export class DlnaClient {
     return Math.max(0, hours * 3600 + minutes * 60 + seconds);
   }
 
-  /** Format seconds as H:MM:SS for Seek REL_TIME. */
+  /** UPnP RelTime is H+:MM:SS — unpadded hours. Many renderers reject 00:MM:SS. */
   public static formatRelTime(totalSec: number): string {
+    const parts: number[] = DlnaClient.splitHms(totalSec);
+    const mm: string = parts[1] < 10 ? `0${parts[1]}` : `${parts[1]}`;
+    const ss: string = parts[2] < 10 ? `0${parts[2]}` : `${parts[2]}`;
+    return `${parts[0]}:${mm}:${ss}`;
+  }
+
+  public static formatRelTimePadded(totalSec: number): string {
+    const parts: number[] = DlnaClient.splitHms(totalSec);
+    const hh: string = parts[0] < 10 ? `0${parts[0]}` : `${parts[0]}`;
+    const mm: string = parts[1] < 10 ? `0${parts[1]}` : `${parts[1]}`;
+    const ss: string = parts[2] < 10 ? `0${parts[2]}` : `${parts[2]}`;
+    return `${hh}:${mm}:${ss}`;
+  }
+
+  private static splitHms(totalSec: number): number[] {
     let sec: number = Math.max(0, Math.floor(totalSec));
     const hours: number = Math.floor(sec / 3600);
     sec = sec % 3600;
-    const minutes: number = Math.floor(sec / 60);
-    const seconds: number = sec % 60;
-    const mm: string = minutes < 10 ? `0${minutes}` : `${minutes}`;
-    const ss: string = seconds < 10 ? `0${seconds}` : `${seconds}`;
-    return `${hours}:${mm}:${ss}`;
+    return [hours, Math.floor(sec / 60), sec % 60];
   }
 
   private async startUdpListener(token: number, onUpdate?: (list: DlnaDevice[]) => void): Promise<void> {
@@ -242,25 +298,21 @@ export class DlnaClient {
   }
 
   private handleSsdpText(text: string, token: number, onUpdate?: (list: DlnaDevice[]) => void): void {
-    if (!text || text.indexOf('LOCATION:') < 0 && text.indexOf('Location:') < 0) {
-      // Still accept lowercase variants via header parse.
-    }
     const location: string = this.headerValue(text, 'LOCATION');
-    const usn: string = this.headerValue(text, 'USN') || location;
-    const st: string = this.headerValue(text, 'ST');
     if (!location) {
       return;
     }
-    if (st && st.indexOf('MediaRenderer') < 0 && text.indexOf('MediaRenderer') < 0) {
-      // Prefer MediaRenderer; still allow empty ST (NOTIFY) if LOCATION looks usable.
-      if (text.indexOf('NOTIFY') >= 0 && text.indexOf('MediaRenderer') < 0) {
-        return;
-      }
-    }
-    if (this.devices.has(usn)) {
+    const rawUsn: string = this.headerValue(text, 'USN') || location;
+    const st: string = this.headerValue(text, 'ST');
+    const nt: string = this.headerValue(text, 'NT');
+    // UPnP 同一台设备会为 root/MediaRenderer/AVTransport/RCS 各发一条，USN 后缀不同。
+    if (`${st} ${nt} ${rawUsn}`.indexOf('MediaRenderer') < 0) {
       return;
     }
-    // Placeholder until description XML is fetched.
+    const usn: string = this.deviceId(rawUsn, location);
+    if (this.devices.has(usn) || this.hasLocation(location)) {
+      return;
+    }
     this.devices.set(usn, {
       usn: usn,
       friendlyName: this.guessName(usn, location),
@@ -357,7 +409,7 @@ export class DlnaClient {
       });
       const code: number = response.responseCode;
       const resultText: string = typeof response.result === 'string' ? response.result : '';
-      if (code < 200 || code >= 300) {
+      if (code < 200 || code >= 300 || /<\w*:?Fault[\s>]/i.test(resultText)) {
         console.error(`${DlnaClient.TAG} SOAP ${action} HTTP ${code}: ${resultText.substring(0, 200)}`);
         throw new Error(`投屏指令失败 (${action}, HTTP ${code})`);
       }
@@ -368,9 +420,9 @@ export class DlnaClient {
     }
   }
 
-  private buildSetUriBody(mediaUrl: string, title: string): string {
+  private buildSetUriBody(mediaUrl: string, title: string, durationSec: number = 0): string {
     const safeUrl: string = this.xmlEscape(mediaUrl);
-    const meta: string = this.xmlEscape(this.buildDidl(mediaUrl, title));
+    const meta: string = this.xmlEscape(this.buildDidl(mediaUrl, title, durationSec));
     return `<u:SetAVTransportURI xmlns:u="${DlnaClient.AVT}">` +
       '<InstanceID>0</InstanceID>' +
       `<CurrentURI>${safeUrl}</CurrentURI>` +
@@ -383,14 +435,18 @@ export class DlnaClient {
       '<InstanceID>0</InstanceID><Speed>1</Speed></u:Play>';
   }
 
+  private buildPauseBody(): string {
+    return `<u:Pause xmlns:u="${DlnaClient.AVT}"><InstanceID>0</InstanceID></u:Pause>`;
+  }
+
   private buildStopBody(): string {
     return `<u:Stop xmlns:u="${DlnaClient.AVT}"><InstanceID>0</InstanceID></u:Stop>`;
   }
 
-  private buildSeekBody(target: string): string {
+  private buildSeekBody(target: string, unit: string = 'REL_TIME'): string {
     return `<u:Seek xmlns:u="${DlnaClient.AVT}">` +
       '<InstanceID>0</InstanceID>' +
-      '<Unit>REL_TIME</Unit>' +
+      `<Unit>${unit}</Unit>` +
       `<Target>${this.xmlEscape(target)}</Target>` +
       '</u:Seek>';
   }
@@ -416,16 +472,18 @@ export class DlnaClient {
       `<DesiredVolume>${volume}</DesiredVolume></u:SetVolume>`;
   }
 
-  private buildDidl(mediaUrl: string, title: string): string {
+  private buildDidl(mediaUrl: string, title: string, durationSec: number = 0): string {
     const safeTitle: string = this.xmlEscape(title || 'EcoHub');
     const safeUrl: string = this.xmlEscape(mediaUrl);
+    const durAttr: string = durationSec > 1 ?
+      ` duration="${DlnaClient.formatRelTime(durationSec)}"` : '';
     return '<DIDL-Lite xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/" ' +
       'xmlns:dc="http://purl.org/dc/elements/1.1/" ' +
       'xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/">' +
       '<item id="0" parentID="-1" restricted="1">' +
       `<dc:title>${safeTitle}</dc:title>` +
       '<upnp:class>object.item.videoItem</upnp:class>' +
-      `<res protocolInfo="http-get:*:*:*">${safeUrl}</res>` +
+      `<res protocolInfo="http-get:*:*:*"${durAttr}>${safeUrl}</res>` +
       '</item></DIDL-Lite>';
   }
 
@@ -460,12 +518,37 @@ export class DlnaClient {
   }
 
   private extractTag(xml: string, tag: string): string {
-    const re: RegExp = new RegExp(`<${tag}[^>]*>([\\s\\S]*?)</${tag}>`, 'i');
-    const m: RegExpMatchArray | null = xml.match(re);
-    if (!m || !m[1]) {
-      return '';
+    const plain: RegExp = new RegExp(`<${tag}(?:\\s[^>]*)?>([\\s\\S]*?)</${tag}>`, 'i');
+    const pm: RegExpMatchArray | null = xml.match(plain);
+    if (pm && pm[1]) {
+      return this.stripCdata(pm[1]);
     }
-    return m[1].replace(/<!\[CDATA\[([\s\S]*?)\]\]>/g, '$1').trim();
+    const ns: RegExp = new RegExp(
+      `<([A-Za-z_][\\w.-]*):${tag}(?:\\s[^>]*)?>([\\s\\S]*?)</\\1:${tag}>`, 'i');
+    const nm: RegExpMatchArray | null = xml.match(ns);
+    if (nm && nm[2]) {
+      return this.stripCdata(nm[2]);
+    }
+    return '';
+  }
+
+  private stripCdata(raw: string): string {
+    return raw.replace(/<!\[CDATA\[([\s\S]*?)\]\]>/g, '$1').trim();
+  }
+
+  /** Unescaped or entity-escaped XML attribute, e.g. DIDL res duration. */
+  private extractAttr(xml: string, name: string): string {
+    const q: RegExp = new RegExp(`${name}="([^"]+)"`, 'i');
+    const m1: RegExpMatchArray | null = xml.match(q);
+    if (m1 && m1[1]) {
+      return m1[1].trim();
+    }
+    const e: RegExp = new RegExp(`${name}=&quot;([^&]+)&quot;`, 'i');
+    const m2: RegExpMatchArray | null = xml.match(e);
+    if (m2 && m2[1]) {
+      return m2[1].trim();
+    }
+    return '';
   }
 
   private resolveUrl(location: string, path: string): string {
@@ -544,6 +627,26 @@ export class DlnaClient {
       list.push(d);
     });
     return list;
+  }
+
+  /** uuid:xxx::urn:... → uuid:xxx，同一物理设备只留一条。 */
+  private deviceId(usn: string, location: string): string {
+    if (usn.indexOf('uuid:') === 0) {
+      const cut: number = usn.indexOf('::');
+      return cut >= 0 ? usn.substring(0, cut) : usn;
+    }
+    return location;
+  }
+
+  private hasLocation(location: string): boolean {
+    const loc: string = location.trim();
+    let found: boolean = false;
+    this.devices.forEach((d: DlnaDevice) => {
+      if (d.location === loc) {
+        found = true;
+      }
+    });
+    return found;
   }
 
   private sleep(ms: number): Promise<void> {

--- a/entry/src/main/ets/common/utils/DlnaClient.ets
+++ b/entry/src/main/ets/common/utils/DlnaClient.ets
@@ -1,6 +1,6 @@
 import { http, socket } from '@kit.NetworkKit';
 import { BusinessError } from '@kit.BasicServicesKit';
-import { DlnaDevice } from './DlnaTypes';
+import { DlnaDevice, DlnaPositionInfo } from './DlnaTypes';
 
 interface SsdpMessageInfo {
   message: ArrayBuffer;
@@ -8,7 +8,8 @@ interface SsdpMessageInfo {
 }
 
 /**
- * Minimal DLNA MediaRenderer client: SSDP discovery + AVTransport SetURI/Play/Stop.
+ * DLNA MediaRenderer client: SSDP discovery + AVTransport + RenderingControl.
+ * Supports SetURI/Play/Stop/Seek/GetPositionInfo and Master volume Get/Set.
  */
 export class DlnaClient {
   private static readonly TAG: string = '[DlnaClient]';
@@ -16,6 +17,7 @@ export class DlnaClient {
   private static readonly SSDP_PORT: number = 1900;
   private static readonly SCAN_MS: number = 4000;
   private static readonly AVT: string = 'urn:schemas-upnp-org:service:AVTransport:1';
+  private static readonly RCS: string = 'urn:schemas-upnp-org:service:RenderingControl:1';
   private static readonly RENDERER: string = 'urn:schemas-upnp-org:device:MediaRenderer:1';
 
   private udp: socket.UDPSocket | null = null;
@@ -69,13 +71,105 @@ export class DlnaClient {
       throw new Error('当前没有可投屏的地址');
     }
     console.info(`${DlnaClient.TAG} cast -> ${device.friendlyName} ${device.controlURL}`);
-    await this.soapAction(device.controlURL, 'SetAVTransportURI', this.buildSetUriBody(mediaUrl, title));
-    await this.soapAction(device.controlURL, 'Play', this.buildPlayBody());
+    await this.soapAction(device.controlURL, DlnaClient.AVT, 'SetAVTransportURI',
+      this.buildSetUriBody(mediaUrl, title));
+    await this.soapAction(device.controlURL, DlnaClient.AVT, 'Play', this.buildPlayBody());
   }
 
   public async stop(device: DlnaDevice): Promise<void> {
     console.info(`${DlnaClient.TAG} stop -> ${device.friendlyName}`);
-    await this.soapAction(device.controlURL, 'Stop', this.buildStopBody());
+    await this.soapAction(device.controlURL, DlnaClient.AVT, 'Stop', this.buildStopBody());
+  }
+
+  public async seek(device: DlnaDevice, positionSec: number): Promise<void> {
+    const target: string = DlnaClient.formatRelTime(positionSec);
+    console.info(`${DlnaClient.TAG} seek -> ${device.friendlyName} ${target}`);
+    await this.soapAction(device.controlURL, DlnaClient.AVT, 'Seek', this.buildSeekBody(target));
+  }
+
+  public async getPositionInfo(device: DlnaDevice): Promise<DlnaPositionInfo> {
+    const xml: string = await this.soapAction(device.controlURL, DlnaClient.AVT, 'GetPositionInfo',
+      this.buildGetPositionInfoBody());
+    const relTime: string = this.extractTag(xml, 'RelTime');
+    const trackDuration: string = this.extractTag(xml, 'TrackDuration');
+    return {
+      positionSec: DlnaClient.parseRelTime(relTime),
+      durationSec: DlnaClient.parseRelTime(trackDuration),
+      relTime: relTime,
+      trackDuration: trackDuration
+    };
+  }
+
+  /** Optional transport state: PLAYING / PAUSED_PLAYBACK / STOPPED / … */
+  public async getTransportInfo(device: DlnaDevice): Promise<string> {
+    const xml: string = await this.soapAction(device.controlURL, DlnaClient.AVT, 'GetTransportInfo',
+      this.buildGetTransportInfoBody());
+    return this.extractTag(xml, 'CurrentTransportState');
+  }
+
+  public async getVolume(device: DlnaDevice): Promise<number> {
+    if (!device.renderingControlURL) {
+      throw new Error('设备不支持音量控制');
+    }
+    const xml: string = await this.soapAction(device.renderingControlURL, DlnaClient.RCS, 'GetVolume',
+      this.buildGetVolumeBody());
+    const raw: string = this.extractTag(xml, 'CurrentVolume');
+    const vol: number = parseInt(raw, 10);
+    if (isNaN(vol)) {
+      return 0;
+    }
+    return Math.max(0, Math.min(100, vol));
+  }
+
+  public async setVolume(device: DlnaDevice, volume: number): Promise<void> {
+    if (!device.renderingControlURL) {
+      throw new Error('设备不支持音量控制');
+    }
+    const clamped: number = Math.max(0, Math.min(100, Math.round(volume)));
+    await this.soapAction(device.renderingControlURL, DlnaClient.RCS, 'SetVolume',
+      this.buildSetVolumeBody(clamped));
+  }
+
+  /** Parse UPnP RelTime / TrackDuration (H:MM:SS or HH:MM:SS). */
+  public static parseRelTime(value: string): number {
+    if (!value) {
+      return 0;
+    }
+    const trimmed: string = value.trim();
+    if (!trimmed || trimmed === 'NOT_IMPLEMENTED' || trimmed.indexOf(':') < 0) {
+      return 0;
+    }
+    const parts: string[] = trimmed.split(':');
+    if (parts.length < 2) {
+      return 0;
+    }
+    let hours: number = 0;
+    let minutes: number = 0;
+    let seconds: number = 0;
+    if (parts.length === 2) {
+      minutes = parseInt(parts[0], 10);
+      seconds = parseInt(parts[1], 10);
+    } else {
+      hours = parseInt(parts[0], 10);
+      minutes = parseInt(parts[1], 10);
+      seconds = parseInt(parts[2], 10);
+    }
+    if (isNaN(hours) || isNaN(minutes) || isNaN(seconds)) {
+      return 0;
+    }
+    return Math.max(0, hours * 3600 + minutes * 60 + seconds);
+  }
+
+  /** Format seconds as H:MM:SS for Seek REL_TIME. */
+  public static formatRelTime(totalSec: number): string {
+    let sec: number = Math.max(0, Math.floor(totalSec));
+    const hours: number = Math.floor(sec / 3600);
+    sec = sec % 3600;
+    const minutes: number = Math.floor(sec / 60);
+    const seconds: number = sec % 60;
+    const mm: string = minutes < 10 ? `0${minutes}` : `${minutes}`;
+    const ss: string = seconds < 10 ? `0${seconds}` : `${seconds}`;
+    return `${hours}:${mm}:${ss}`;
   }
 
   private async startUdpListener(token: number, onUpdate?: (list: DlnaDevice[]) => void): Promise<void> {
@@ -173,6 +267,7 @@ export class DlnaClient {
       manufacturer: '',
       location: location,
       controlURL: '',
+      renderingControlURL: '',
       host: this.hostOf(location)
     });
     this.fetchDescription(usn, location, token, onUpdate);
@@ -188,7 +283,7 @@ export class DlnaClient {
       if (token !== this.scanToken) {
         return;
       }
-      const controlURL: string = this.findAvTransportControlUrl(xml, location);
+      const controlURL: string = this.findServiceControlUrl(xml, location, 'AVTransport');
       if (!controlURL) {
         console.info(`${DlnaClient.TAG} no AVTransport at ${location}`);
         this.devices.delete(usn);
@@ -197,16 +292,19 @@ export class DlnaClient {
         }
         return;
       }
+      const rcsURL: string = this.findServiceControlUrl(xml, location, 'RenderingControl');
       const device: DlnaDevice = {
         usn: usn,
         friendlyName: this.extractTag(xml, 'friendlyName') || this.guessName(usn, location),
         manufacturer: this.extractTag(xml, 'manufacturer'),
         location: location,
         controlURL: controlURL,
+        renderingControlURL: rcsURL,
         host: this.hostOf(location)
       };
       this.devices.set(usn, device);
-      console.info(`${DlnaClient.TAG} found ${device.friendlyName} @ ${device.host}`);
+      console.info(`${DlnaClient.TAG} found ${device.friendlyName} @ ${device.host}` +
+        ` rcs=${rcsURL ? 'yes' : 'no'}`);
       if (onUpdate) {
         onUpdate(this.listDevices().filter((d: DlnaDevice) => !!d.controlURL));
       }
@@ -216,13 +314,13 @@ export class DlnaClient {
     });
   }
 
-  private findAvTransportControlUrl(xml: string, baseLocation: string): string {
+  private findServiceControlUrl(xml: string, baseLocation: string, serviceName: string): string {
     const serviceRe: RegExp = /<service\b[\s\S]*?<\/service>/gi;
     let match: RegExpExecArray | null = serviceRe.exec(xml);
     while (match) {
       const block: string = match[0];
       const serviceType: string = this.extractTag(block, 'serviceType');
-      if (serviceType.indexOf('AVTransport') >= 0) {
+      if (serviceType.indexOf(serviceName) >= 0) {
         const control: string = this.extractTag(block, 'controlURL');
         if (control) {
           return this.resolveUrl(baseLocation, control);
@@ -233,7 +331,12 @@ export class DlnaClient {
     return '';
   }
 
-  private async soapAction(controlURL: string, action: string, bodyInner: string): Promise<void> {
+  private async soapAction(
+    controlURL: string,
+    serviceType: string,
+    action: string,
+    bodyInner: string
+  ): Promise<string> {
     const envelope: string =
       '<?xml version="1.0" encoding="utf-8"?>' +
       '<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" ' +
@@ -245,7 +348,7 @@ export class DlnaClient {
         method: http.RequestMethod.POST,
         header: {
           'Content-Type': 'text/xml; charset="utf-8"',
-          'SOAPAction': `"${DlnaClient.AVT}#${action}"`
+          'SOAPAction': `"${serviceType}#${action}"`
         },
         extraData: envelope,
         expectDataType: http.HttpDataType.STRING,
@@ -253,12 +356,13 @@ export class DlnaClient {
         readTimeout: 8000
       });
       const code: number = response.responseCode;
+      const resultText: string = typeof response.result === 'string' ? response.result : '';
       if (code < 200 || code >= 300) {
-        const resultText: string = typeof response.result === 'string' ? response.result : '';
         console.error(`${DlnaClient.TAG} SOAP ${action} HTTP ${code}: ${resultText.substring(0, 200)}`);
         throw new Error(`投屏指令失败 (${action}, HTTP ${code})`);
       }
       console.info(`${DlnaClient.TAG} SOAP ${action} ok`);
+      return resultText;
     } finally {
       httpRequest.destroy();
     }
@@ -281,6 +385,35 @@ export class DlnaClient {
 
   private buildStopBody(): string {
     return `<u:Stop xmlns:u="${DlnaClient.AVT}"><InstanceID>0</InstanceID></u:Stop>`;
+  }
+
+  private buildSeekBody(target: string): string {
+    return `<u:Seek xmlns:u="${DlnaClient.AVT}">` +
+      '<InstanceID>0</InstanceID>' +
+      '<Unit>REL_TIME</Unit>' +
+      `<Target>${this.xmlEscape(target)}</Target>` +
+      '</u:Seek>';
+  }
+
+  private buildGetPositionInfoBody(): string {
+    return `<u:GetPositionInfo xmlns:u="${DlnaClient.AVT}">` +
+      '<InstanceID>0</InstanceID></u:GetPositionInfo>';
+  }
+
+  private buildGetTransportInfoBody(): string {
+    return `<u:GetTransportInfo xmlns:u="${DlnaClient.AVT}">` +
+      '<InstanceID>0</InstanceID></u:GetTransportInfo>';
+  }
+
+  private buildGetVolumeBody(): string {
+    return `<u:GetVolume xmlns:u="${DlnaClient.RCS}">` +
+      '<InstanceID>0</InstanceID><Channel>Master</Channel></u:GetVolume>';
+  }
+
+  private buildSetVolumeBody(volume: number): string {
+    return `<u:SetVolume xmlns:u="${DlnaClient.RCS}">` +
+      '<InstanceID>0</InstanceID><Channel>Master</Channel>' +
+      `<DesiredVolume>${volume}</DesiredVolume></u:SetVolume>`;
   }
 
   private buildDidl(mediaUrl: string, title: string): string {

--- a/entry/src/main/ets/common/utils/DlnaClient.ets
+++ b/entry/src/main/ets/common/utils/DlnaClient.ets
@@ -1,0 +1,448 @@
+import { http, socket } from '@kit.NetworkKit';
+import { BusinessError } from '@kit.BasicServicesKit';
+import { DlnaDevice } from './DlnaTypes';
+
+interface SsdpMessageInfo {
+  message: ArrayBuffer;
+  remoteInfo: socket.SocketRemoteInfo;
+}
+
+/**
+ * Minimal DLNA MediaRenderer client: SSDP discovery + AVTransport SetURI/Play/Stop.
+ */
+export class DlnaClient {
+  private static readonly TAG: string = '[DlnaClient]';
+  private static readonly SSDP_ADDR: string = '239.255.255.250';
+  private static readonly SSDP_PORT: number = 1900;
+  private static readonly SCAN_MS: number = 4000;
+  private static readonly AVT: string = 'urn:schemas-upnp-org:service:AVTransport:1';
+  private static readonly RENDERER: string = 'urn:schemas-upnp-org:device:MediaRenderer:1';
+
+  private udp: socket.UDPSocket | null = null;
+  private multicast: socket.MulticastSocket | null = null;
+  private scanToken: number = 0;
+  private devices: Map<string, DlnaDevice> = new Map();
+
+  public async discover(onUpdate?: (list: DlnaDevice[]) => void): Promise<DlnaDevice[]> {
+    this.scanToken += 1;
+    const token: number = this.scanToken;
+    this.devices.clear();
+    this.closeSockets();
+
+    const msearch: string =
+      'M-SEARCH * HTTP/1.1\r\n' +
+      `HOST: ${DlnaClient.SSDP_ADDR}:${DlnaClient.SSDP_PORT}\r\n` +
+      'MAN: "ssdp:discover"\r\n' +
+      'MX: 3\r\n' +
+      `ST: ${DlnaClient.RENDERER}\r\n` +
+      '\r\n';
+
+    try {
+      await this.startUdpListener(token, onUpdate);
+      await this.sendMSearch(msearch);
+      // Multicast membership helps some LANs deliver replies / NOTIFY.
+      await this.tryMulticastListen(token, msearch, onUpdate);
+    } catch (err) {
+      const msg: string = err instanceof Error ? err.message : JSON.stringify(err);
+      console.error(`${DlnaClient.TAG} discover start failed: ${msg}`);
+      this.closeSockets();
+      throw new Error(msg || 'SSDP 扫描失败');
+    }
+
+    await this.sleep(DlnaClient.SCAN_MS);
+    if (token !== this.scanToken) {
+      return [];
+    }
+    this.closeSockets();
+    const list: DlnaDevice[] = this.listDevices();
+    console.info(`${DlnaClient.TAG} discover done, count=${list.length}`);
+    return list;
+  }
+
+  public cancelDiscover(): void {
+    this.scanToken += 1;
+    this.closeSockets();
+  }
+
+  public async cast(device: DlnaDevice, mediaUrl: string, title: string = 'EcoHub'): Promise<void> {
+    if (!mediaUrl) {
+      throw new Error('当前没有可投屏的地址');
+    }
+    console.info(`${DlnaClient.TAG} cast -> ${device.friendlyName} ${device.controlURL}`);
+    await this.soapAction(device.controlURL, 'SetAVTransportURI', this.buildSetUriBody(mediaUrl, title));
+    await this.soapAction(device.controlURL, 'Play', this.buildPlayBody());
+  }
+
+  public async stop(device: DlnaDevice): Promise<void> {
+    console.info(`${DlnaClient.TAG} stop -> ${device.friendlyName}`);
+    await this.soapAction(device.controlURL, 'Stop', this.buildStopBody());
+  }
+
+  private async startUdpListener(token: number, onUpdate?: (list: DlnaDevice[]) => void): Promise<void> {
+    const udp: socket.UDPSocket = socket.constructUDPSocketInstance();
+    this.udp = udp;
+    udp.on('message', (info: SsdpMessageInfo) => {
+      if (token !== this.scanToken) {
+        return;
+      }
+      const text: string = this.bufferToString(info.message);
+      this.handleSsdpText(text, token, onUpdate);
+    });
+    udp.on('error', (err: BusinessError) => {
+      console.error(`${DlnaClient.TAG} udp error: ${JSON.stringify(err)}`);
+    });
+    const local: socket.NetAddress = {
+      address: '0.0.0.0',
+      port: 0,
+      family: 1
+    };
+    await udp.bind(local);
+    console.info(`${DlnaClient.TAG} udp bound`);
+  }
+
+  private async sendMSearch(msearch: string): Promise<void> {
+    if (!this.udp) {
+      return;
+    }
+    const remote: socket.NetAddress = {
+      address: DlnaClient.SSDP_ADDR,
+      port: DlnaClient.SSDP_PORT,
+      family: 1
+    };
+    await this.udp.send({ data: msearch, address: remote });
+    // A second burst improves hit rate on busy LANs.
+    await this.sleep(300);
+    if (this.udp) {
+      await this.udp.send({ data: msearch, address: remote });
+    }
+    console.info(`${DlnaClient.TAG} M-SEARCH sent`);
+  }
+
+  private async tryMulticastListen(
+    token: number,
+    msearch: string,
+    onUpdate?: (list: DlnaDevice[]) => void
+  ): Promise<void> {
+    try {
+      const mc: socket.MulticastSocket = socket.constructMulticastSocketInstance();
+      this.multicast = mc;
+      const addr: socket.NetAddress = {
+        address: DlnaClient.SSDP_ADDR,
+        port: DlnaClient.SSDP_PORT,
+        family: 1
+      };
+      await mc.addMembership(addr);
+      mc.on('message', (info: SsdpMessageInfo) => {
+        if (token !== this.scanToken) {
+          return;
+        }
+        const text: string = this.bufferToString(info.message);
+        this.handleSsdpText(text, token, onUpdate);
+      });
+      await mc.send({ data: msearch, address: addr });
+      console.info(`${DlnaClient.TAG} multicast membership ok`);
+    } catch (err) {
+      // Multicast is best-effort; UDP unicast replies are enough on many LANs.
+      console.info(`${DlnaClient.TAG} multicast optional failed: ${JSON.stringify(err)}`);
+    }
+  }
+
+  private handleSsdpText(text: string, token: number, onUpdate?: (list: DlnaDevice[]) => void): void {
+    if (!text || text.indexOf('LOCATION:') < 0 && text.indexOf('Location:') < 0) {
+      // Still accept lowercase variants via header parse.
+    }
+    const location: string = this.headerValue(text, 'LOCATION');
+    const usn: string = this.headerValue(text, 'USN') || location;
+    const st: string = this.headerValue(text, 'ST');
+    if (!location) {
+      return;
+    }
+    if (st && st.indexOf('MediaRenderer') < 0 && text.indexOf('MediaRenderer') < 0) {
+      // Prefer MediaRenderer; still allow empty ST (NOTIFY) if LOCATION looks usable.
+      if (text.indexOf('NOTIFY') >= 0 && text.indexOf('MediaRenderer') < 0) {
+        return;
+      }
+    }
+    if (this.devices.has(usn)) {
+      return;
+    }
+    // Placeholder until description XML is fetched.
+    this.devices.set(usn, {
+      usn: usn,
+      friendlyName: this.guessName(usn, location),
+      manufacturer: '',
+      location: location,
+      controlURL: '',
+      host: this.hostOf(location)
+    });
+    this.fetchDescription(usn, location, token, onUpdate);
+  }
+
+  private fetchDescription(
+    usn: string,
+    location: string,
+    token: number,
+    onUpdate?: (list: DlnaDevice[]) => void
+  ): void {
+    this.httpGet(location).then((xml: string) => {
+      if (token !== this.scanToken) {
+        return;
+      }
+      const controlURL: string = this.findAvTransportControlUrl(xml, location);
+      if (!controlURL) {
+        console.info(`${DlnaClient.TAG} no AVTransport at ${location}`);
+        this.devices.delete(usn);
+        if (onUpdate) {
+          onUpdate(this.listDevices().filter((d: DlnaDevice) => !!d.controlURL));
+        }
+        return;
+      }
+      const device: DlnaDevice = {
+        usn: usn,
+        friendlyName: this.extractTag(xml, 'friendlyName') || this.guessName(usn, location),
+        manufacturer: this.extractTag(xml, 'manufacturer'),
+        location: location,
+        controlURL: controlURL,
+        host: this.hostOf(location)
+      };
+      this.devices.set(usn, device);
+      console.info(`${DlnaClient.TAG} found ${device.friendlyName} @ ${device.host}`);
+      if (onUpdate) {
+        onUpdate(this.listDevices().filter((d: DlnaDevice) => !!d.controlURL));
+      }
+    }).catch((err: Object) => {
+      console.error(`${DlnaClient.TAG} desc fetch fail ${location}: ${JSON.stringify(err)}`);
+      this.devices.delete(usn);
+    });
+  }
+
+  private findAvTransportControlUrl(xml: string, baseLocation: string): string {
+    const serviceRe: RegExp = /<service\b[\s\S]*?<\/service>/gi;
+    let match: RegExpExecArray | null = serviceRe.exec(xml);
+    while (match) {
+      const block: string = match[0];
+      const serviceType: string = this.extractTag(block, 'serviceType');
+      if (serviceType.indexOf('AVTransport') >= 0) {
+        const control: string = this.extractTag(block, 'controlURL');
+        if (control) {
+          return this.resolveUrl(baseLocation, control);
+        }
+      }
+      match = serviceRe.exec(xml);
+    }
+    return '';
+  }
+
+  private async soapAction(controlURL: string, action: string, bodyInner: string): Promise<void> {
+    const envelope: string =
+      '<?xml version="1.0" encoding="utf-8"?>' +
+      '<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" ' +
+      's:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">' +
+      `<s:Body>${bodyInner}</s:Body></s:Envelope>`;
+    const httpRequest: http.HttpRequest = http.createHttp();
+    try {
+      const response: http.HttpResponse = await httpRequest.request(controlURL, {
+        method: http.RequestMethod.POST,
+        header: {
+          'Content-Type': 'text/xml; charset="utf-8"',
+          'SOAPAction': `"${DlnaClient.AVT}#${action}"`
+        },
+        extraData: envelope,
+        expectDataType: http.HttpDataType.STRING,
+        connectTimeout: 8000,
+        readTimeout: 8000
+      });
+      const code: number = response.responseCode;
+      if (code < 200 || code >= 300) {
+        const resultText: string = typeof response.result === 'string' ? response.result : '';
+        console.error(`${DlnaClient.TAG} SOAP ${action} HTTP ${code}: ${resultText.substring(0, 200)}`);
+        throw new Error(`投屏指令失败 (${action}, HTTP ${code})`);
+      }
+      console.info(`${DlnaClient.TAG} SOAP ${action} ok`);
+    } finally {
+      httpRequest.destroy();
+    }
+  }
+
+  private buildSetUriBody(mediaUrl: string, title: string): string {
+    const safeUrl: string = this.xmlEscape(mediaUrl);
+    const meta: string = this.xmlEscape(this.buildDidl(mediaUrl, title));
+    return `<u:SetAVTransportURI xmlns:u="${DlnaClient.AVT}">` +
+      '<InstanceID>0</InstanceID>' +
+      `<CurrentURI>${safeUrl}</CurrentURI>` +
+      `<CurrentURIMetaData>${meta}</CurrentURIMetaData>` +
+      '</u:SetAVTransportURI>';
+  }
+
+  private buildPlayBody(): string {
+    return `<u:Play xmlns:u="${DlnaClient.AVT}">` +
+      '<InstanceID>0</InstanceID><Speed>1</Speed></u:Play>';
+  }
+
+  private buildStopBody(): string {
+    return `<u:Stop xmlns:u="${DlnaClient.AVT}"><InstanceID>0</InstanceID></u:Stop>`;
+  }
+
+  private buildDidl(mediaUrl: string, title: string): string {
+    const safeTitle: string = this.xmlEscape(title || 'EcoHub');
+    const safeUrl: string = this.xmlEscape(mediaUrl);
+    return '<DIDL-Lite xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/" ' +
+      'xmlns:dc="http://purl.org/dc/elements/1.1/" ' +
+      'xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/">' +
+      '<item id="0" parentID="-1" restricted="1">' +
+      `<dc:title>${safeTitle}</dc:title>` +
+      '<upnp:class>object.item.videoItem</upnp:class>' +
+      `<res protocolInfo="http-get:*:*:*">${safeUrl}</res>` +
+      '</item></DIDL-Lite>';
+  }
+
+  private async httpGet(url: string): Promise<string> {
+    const httpRequest: http.HttpRequest = http.createHttp();
+    try {
+      const response: http.HttpResponse = await httpRequest.request(url, {
+        method: http.RequestMethod.GET,
+        expectDataType: http.HttpDataType.STRING,
+        connectTimeout: 5000,
+        readTimeout: 5000
+      });
+      if (response.responseCode < 200 || response.responseCode >= 300) {
+        throw new Error(`HTTP ${response.responseCode}`);
+      }
+      return typeof response.result === 'string' ? response.result : '';
+    } finally {
+      httpRequest.destroy();
+    }
+  }
+
+  private headerValue(text: string, name: string): string {
+    const lines: string[] = text.split(/\r?\n/);
+    const prefix: string = name.toUpperCase() + ':';
+    for (let i = 0; i < lines.length; i++) {
+      const line: string = lines[i];
+      if (line.toUpperCase().indexOf(prefix) === 0) {
+        return line.substring(line.indexOf(':') + 1).trim();
+      }
+    }
+    return '';
+  }
+
+  private extractTag(xml: string, tag: string): string {
+    const re: RegExp = new RegExp(`<${tag}[^>]*>([\\s\\S]*?)</${tag}>`, 'i');
+    const m: RegExpMatchArray | null = xml.match(re);
+    if (!m || !m[1]) {
+      return '';
+    }
+    return m[1].replace(/<!\[CDATA\[([\s\S]*?)\]\]>/g, '$1').trim();
+  }
+
+  private resolveUrl(location: string, path: string): string {
+    const trimmed: string = path.trim();
+    if (trimmed.indexOf('http://') === 0 || trimmed.indexOf('https://') === 0) {
+      return trimmed;
+    }
+    const schemeIdx: number = location.indexOf('://');
+    if (schemeIdx < 0) {
+      return trimmed;
+    }
+    const afterScheme: string = location.substring(schemeIdx + 3);
+    const slash: number = afterScheme.indexOf('/');
+    const origin: string = slash >= 0 ? location.substring(0, schemeIdx + 3 + slash) : location;
+    if (trimmed.indexOf('/') === 0) {
+      return origin + trimmed;
+    }
+    const lastSlash: number = location.lastIndexOf('/');
+    const dir: string = lastSlash > schemeIdx + 2 ? location.substring(0, lastSlash + 1) : origin + '/';
+    return dir + trimmed;
+  }
+
+  private hostOf(location: string): string {
+    const schemeIdx: number = location.indexOf('://');
+    if (schemeIdx < 0) {
+      return location;
+    }
+    const after: string = location.substring(schemeIdx + 3);
+    const slash: number = after.indexOf('/');
+    return slash >= 0 ? after.substring(0, slash) : after;
+  }
+
+  private guessName(usn: string, location: string): string {
+    if (usn) {
+      const parts: string[] = usn.split(':');
+      if (parts.length > 1) {
+        return parts[parts.length - 1].substring(0, 24) || this.hostOf(location);
+      }
+    }
+    return this.hostOf(location) || 'DLNA 设备';
+  }
+
+  private xmlEscape(value: string): string {
+    let out: string = '';
+    for (let i = 0; i < value.length; i++) {
+      const ch: string = value.charAt(i);
+      if (ch === '&') {
+        out += '&amp;';
+      } else if (ch === '<') {
+        out += '&lt;';
+      } else if (ch === '>') {
+        out += '&gt;';
+      } else if (ch === '"') {
+        out += '&quot;';
+      } else if (ch === '\'') {
+        out += '&apos;';
+      } else {
+        out += ch;
+      }
+    }
+    return out;
+  }
+
+  private bufferToString(buf: ArrayBuffer): string {
+    const bytes: Uint8Array = new Uint8Array(buf);
+    let str: string = '';
+    for (let i = 0; i < bytes.length; i++) {
+      str += String.fromCharCode(bytes[i]);
+    }
+    return str;
+  }
+
+  private listDevices(): DlnaDevice[] {
+    const list: DlnaDevice[] = [];
+    this.devices.forEach((d: DlnaDevice) => {
+      list.push(d);
+    });
+    return list;
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise<void>((resolve: () => void) => {
+      setTimeout(() => {
+        resolve();
+      }, ms);
+    });
+  }
+
+  private closeSockets(): void {
+    if (this.udp) {
+      try {
+        this.udp.off('message');
+        this.udp.off('error');
+        this.udp.close();
+      } catch (_e) {
+      }
+      this.udp = null;
+    }
+    if (this.multicast) {
+      try {
+        this.multicast.off('message');
+        const addr: socket.NetAddress = {
+          address: DlnaClient.SSDP_ADDR,
+          port: DlnaClient.SSDP_PORT,
+          family: 1
+        };
+        this.multicast.dropMembership(addr).catch(() => {});
+      } catch (_e) {
+      }
+      this.multicast = null;
+    }
+  }
+}

--- a/entry/src/main/ets/common/utils/DlnaTypes.ets
+++ b/entry/src/main/ets/common/utils/DlnaTypes.ets
@@ -29,3 +29,80 @@ export enum DlnaScanState {
   DONE = 2,
   ERROR = 3
 }
+
+/** SOAP Fault / HTTP error. Plain class — ArkTS does not like `extends Error`. */
+export class DlnaSoapError {
+  action: string = '';
+  httpCode: number = 0;
+  errorCode: number = 0;
+  errorDescription: string = '';
+  message: string = '';
+
+  /** Fatal only for SetAVTransportURI / Play. Seek/Pause/Stop/Get* never fail the session. */
+  fatalForLaunch(): boolean {
+    if (this.action !== 'SetAVTransportURI' && this.action !== 'Play') {
+      return false;
+    }
+    const c: number = this.errorCode;
+    if (c === 714 || c === 716 || c === 401 || c === 402 || c === 701) {
+      return true;
+    }
+    return c === 0 && this.httpCode >= 400;
+  }
+}
+
+export function asDlnaSoapError(err: Object): DlnaSoapError | null {
+  if (err instanceof DlnaSoapError) {
+    return err;
+  }
+  if (!(err instanceof Error) || !err.message) {
+    return null;
+  }
+  const m: RegExpMatchArray | null = err.message.match(/\(([^,]+), ([^)]+)\)\s*$/);
+  if (!m) {
+    return null;
+  }
+  const soap: DlnaSoapError = new DlnaSoapError();
+  soap.action = m[1];
+  soap.message = err.message;
+  soap.errorDescription = err.message;
+  if (m[2].indexOf('HTTP') === 0) {
+    soap.httpCode = parseInt(m[2].replace('HTTP ', ''), 10);
+    soap.errorCode = 0;
+  } else {
+    const n: number = parseInt(m[2], 10);
+    soap.errorCode = isNaN(n) ? 0 : n;
+  }
+  return soap;
+}
+
+export function soapErrorMessage(err: Object): string {
+  const soap: DlnaSoapError | null = asDlnaSoapError(err);
+  if (soap) {
+    return soap.errorDescription || soap.message || '投屏失败';
+  }
+  if (err instanceof Error) {
+    return err.message || '投屏失败';
+  }
+  return '投屏失败';
+}
+
+/** RelTime empty / NOT_IMPLEMENTED / NOT_IMPLEMENTED. */
+export function isRelTimeUnavailable(raw: string): boolean {
+  const t: string = (raw ? raw : '').trim().toUpperCase();
+  if (!t) {
+    return true;
+  }
+  return t.indexOf('NOT_IMPLEMENTED') === 0;
+}
+
+export class CastPhase {
+  static readonly IDLE: string = 'idle';
+  static readonly LAUNCHING: string = 'launching';
+  static readonly PLAYING: string = 'playing';
+  static readonly PAUSED: string = 'paused';
+  static readonly COMPLETED: string = 'completed';
+  static readonly FAILED: string = 'failed';
+  static readonly DISCONNECTED: string = 'disconnected';
+  static readonly STOPPING: string = 'stopping';
+}

--- a/entry/src/main/ets/common/utils/DlnaTypes.ets
+++ b/entry/src/main/ets/common/utils/DlnaTypes.ets
@@ -1,0 +1,21 @@
+/**
+ * DLNA / UPnP MediaRenderer types for casting.
+ */
+export interface DlnaDevice {
+  /** Unique Service Name from SSDP (stable id). */
+  usn: string;
+  friendlyName: string;
+  manufacturer: string;
+  /** Device description LOCATION URL. */
+  location: string;
+  /** Absolute AVTransport controlURL. */
+  controlURL: string;
+  host: string;
+}
+
+export enum DlnaScanState {
+  IDLE = 0,
+  SCANNING = 1,
+  DONE = 2,
+  ERROR = 3
+}

--- a/entry/src/main/ets/common/utils/DlnaTypes.ets
+++ b/entry/src/main/ets/common/utils/DlnaTypes.ets
@@ -10,7 +10,17 @@ export interface DlnaDevice {
   location: string;
   /** Absolute AVTransport controlURL. */
   controlURL: string;
+  /** Absolute RenderingControl controlURL (may be empty). */
+  renderingControlURL: string;
   host: string;
+}
+
+/** Parsed AVTransport GetPositionInfo. Times are seconds. */
+export interface DlnaPositionInfo {
+  positionSec: number;
+  durationSec: number;
+  relTime: string;
+  trackDuration: string;
 }
 
 export enum DlnaScanState {

--- a/entry/src/main/ets/components/NoticeDialog.ets
+++ b/entry/src/main/ets/components/NoticeDialog.ets
@@ -20,6 +20,17 @@ export struct NoticeDialog {
     return this.windowHeight > 0 && this.windowHeight < 500;
   }
 
+  // 正文随内容收紧；仅在超出上限时滚动，避免短公告被 layoutWeight 撑高
+  private contentMaxHeight(): number {
+    const pad = this.isLandscape() ? 14 : AppTheme.SPACE_LG;
+    const headerGap = this.isLandscape() ? 8 : AppTheme.SPACE_MD;
+    const btnGap = this.isLandscape() ? 10 : AppTheme.SPACE_LG;
+    const btnH = this.isLandscape() ? 36 : 42;
+    const chrome = pad * 2 + 32 + headerGap + btnGap + btnH + Math.max(12, this.bottomInset);
+    const available = this.windowHeight * 0.85 - chrome;
+    return Math.max(48, Math.min(260, available));
+  }
+
   aboutToAppear(): void {
     setTimeout(() => {
       this.maskOpacity = 1;
@@ -99,7 +110,7 @@ export struct NoticeDialog {
         .alignItems(VerticalAlign.Center)
         .margin({ bottom: this.isLandscape() ? 8 : AppTheme.SPACE_MD })
 
-        // 公告正文（可滚动容器，弹性收缩保护底部按钮）
+        // 公告正文：高度随内容，超上限才滚动，横屏用窗口剩余高度封顶保按钮可见
         Scroll() {
           Column() {
             Text(this.content)
@@ -111,11 +122,10 @@ export struct NoticeDialog {
           .width('100%')
           .alignItems(HorizontalAlign.Start)
         }
-        .layoutWeight(1)
         .scrollable(ScrollDirection.Vertical)
         .scrollBar(BarState.Auto)
         .edgeEffect(EdgeEffect.Spring)
-        .constraintSize({ minHeight: 60, maxHeight: 260 })
+        .constraintSize({ maxHeight: this.contentMaxHeight() })
         .width('100%')
         .padding(AppTheme.SPACE_MD)
         .backgroundColor(AppTheme.BG_CARD)

--- a/entry/src/main/ets/components/PlayerCastController.ets
+++ b/entry/src/main/ets/components/PlayerCastController.ets
@@ -1,0 +1,412 @@
+import { CastSession } from '../common/utils/CastSession';
+import { CastPhase, DlnaDevice } from '../common/utils/DlnaTypes';
+import { PlayerAv } from '../common/utils/PlayerAv';
+import { markCastStartSec, peekCastStartSec } from './PlayerCastSheet';
+import { PlayerAudioBridge } from './PlayerAudioBridge';
+import { PlayerPlaybackState, ProgressCallback } from './PlayerPlaybackState';
+import { PlayerStallWatcher } from './PlayerStallWatcher';
+
+export interface PlayerCastHost {
+  state: PlayerPlaybackState;
+  playerAv: PlayerAv;
+  watcher: PlayerStallWatcher;
+  audioBridge: PlayerAudioBridge;
+  videoUrl: string;
+  title: string;
+  hasNext: () => boolean;
+  volumeIndex: number;
+  onEnded?: () => void;
+  onProgress?: ProgressCallback;
+  syncFromState: () => void;
+  syncKeepScreen: () => void;
+  remountPlayer: () => void;
+  pulseHud: () => void;
+  closeCastDialog: () => void;
+  closeSpeedDialog: () => void;
+  openCastSheet: () => void;
+  onCastUi: () => void;
+  toast: (msg: string) => void;
+  fullNow: () => boolean;
+  exitFullForCast: () => void;
+  logicalPlayhead: () => number;
+}
+
+/** Cast orchestration: park/resume local player, recast, volume. Session owns SOAP/poll. */
+export class PlayerCastController {
+  session: CastSession = new CastSession();
+  device: DlnaDevice | null = null;
+  deviceName: string = '';
+  connectedUsn: string = '';
+  startSec: number = 0;
+  wasPlaying: boolean = false;
+  pausedForPicker: boolean = false;
+  keepCastForNext: boolean = false;
+
+  private host: PlayerCastHost | null = null;
+  private endingCast: boolean = false;
+  private absorbingSource: boolean = false;
+  private lastCastVolPct: number = -1;
+  private castVolBusy: boolean = false;
+  private relTimeToasted: boolean = false;
+
+  updateHost(host: PlayerCastHost): void {
+    this.host = host;
+  }
+
+  bindCallbacks(): void {
+    this.session.onFailed = (pos: number) => {
+      this.handleCastPlaybackFailed(pos);
+    };
+    this.session.onCompleted = () => {
+      this.handleCastCompleted();
+    };
+    this.session.onDisconnected = (pos: number) => {
+      this.handleCastDisconnected(pos);
+    };
+    this.session.onState = () => {
+      this.onCastState();
+    };
+  }
+
+  isCasting(): boolean {
+    return !!this.connectedUsn || !!this.deviceName || this.session.active;
+  }
+
+  openCastDialog(): void {
+    const host: PlayerCastHost | null = this.host;
+    if (!host || host.fullNow()) {
+      return;
+    }
+    host.closeSpeedDialog();
+    this.startSec = host.logicalPlayhead();
+    markCastStartSec(this.startSec);
+    this.wasPlaying = host.state.playRequested && !host.state.errorText && !host.state.completed;
+    console.info(`[PlayerCastController] snapshot startSec=${this.startSec} wasPlaying=${this.wasPlaying}`);
+    if (this.wasPlaying) {
+      this.pausedForPicker = true;
+      host.state.playRequested = false;
+      host.state.isPlaying = false;
+      host.playerAv.pause();
+      host.syncFromState();
+    }
+    host.openCastSheet();
+    host.pulseHud();
+  }
+
+  resumeAfterPickerCancel(): void {
+    const host: PlayerCastHost | null = this.host;
+    if (!host || !this.pausedForPicker || this.isCasting()) {
+      this.pausedForPicker = false;
+      return;
+    }
+    this.pausedForPicker = false;
+    host.state.playRequested = true;
+    host.playerAv.play();
+    host.syncFromState();
+  }
+
+  bindCastDevice(device: DlnaDevice): void {
+    const host: PlayerCastHost | null = this.host;
+    if (!host) {
+      return;
+    }
+    this.pausedForPicker = false;
+    this.device = device;
+    this.deviceName = device.friendlyName;
+    this.connectedUsn = device.usn;
+    this.relTimeToasted = false;
+    this.session.attach(device);
+    const start: number = Math.max(this.startSec, peekCastStartSec(), host.state.currentTime);
+    this.session.beginLaunch(start, host.state.duration);
+    console.info(`[PlayerCastController] bind start=${start} dur=${host.state.duration}`);
+    this.lastCastVolPct = -1;
+    this.pushCastVolume();
+    host.exitFullForCast();
+    this.parkPlayerForCast();
+    host.onCastUi();
+    host.closeCastDialog();
+    host.pulseHud();
+  }
+
+  /** @returns true if source change is consumed (recast / absorb); skip remount. */
+  handleSourceChange(): boolean {
+    if (this.keepCastForNext && this.isCasting()) {
+      this.keepCastForNext = false;
+      this.absorbingSource = true;
+      this.recastCurrentUrl();
+      setTimeout(() => {
+        this.absorbingSource = false;
+      }, 0);
+      return true;
+    }
+    if (this.absorbingSource) {
+      return true;
+    }
+    if (this.isCasting() && !this.endingCast) {
+      this.session.stopRemote();
+      this.clearCastLocal();
+    }
+    return false;
+  }
+
+  handleCastCompleted(): void {
+    const host: PlayerCastHost | null = this.host;
+    if (!host) {
+      return;
+    }
+    if (host.hasNext() && host.onEnded) {
+      this.keepCastForNext = true;
+      console.info('[PlayerCastController] completed → onEnded keepCast');
+      host.onEnded();
+      return;
+    }
+    this.finishCastCompleted();
+  }
+
+  endCastByUser(): void {
+    if (this.endingCast || !this.isCasting()) {
+      return;
+    }
+    this.endingCast = true;
+    const host: PlayerCastHost | null = this.host;
+    const pos: number = Math.max(this.session.positionSec, host ? host.state.currentTime : 0);
+    const play: boolean = this.wasPlaying;
+    this.session.stopRemote().then(() => {
+      this.clearCastLocal();
+      this.resumePlayerAfterCast(pos, play);
+      if (host) {
+        host.toast('已停止投屏');
+        host.pulseHud();
+      }
+      this.endingCast = false;
+    });
+  }
+
+  stopSession(): void {
+    this.session.stopRemote();
+    this.clearCastLocal();
+  }
+
+  resumeCastSync(): void {
+    if (!this.session.active) {
+      if (this.device) {
+        this.session.attach(this.device);
+      } else {
+        return;
+      }
+    }
+    this.session.startPoll(this.deviceName ? 1000 : 2000);
+    this.session.refreshVolume();
+  }
+
+  syncCastProgressToState(): void {
+    const host: PlayerCastHost | null = this.host;
+    if (!host || !this.isCasting()) {
+      return;
+    }
+    if (this.session.positionSec > 0) {
+      host.state.currentTime = this.session.positionSec;
+    }
+    if (this.session.durationSec > 0) {
+      host.state.duration = this.session.durationSec;
+    }
+    host.syncFromState();
+  }
+
+  pushCastVolume(): void {
+    if (!this.isCasting()) {
+      return;
+    }
+    const host: PlayerCastHost | null = this.host;
+    const device: DlnaDevice | null = this.device;
+    if (!host || !device || !device.renderingControlURL) {
+      return;
+    }
+    const max: number = Math.max(1, host.audioBridge.max);
+    const pct: number = Math.max(0, Math.min(100, Math.round(host.volumeIndex / max * 100)));
+    if (pct === this.lastCastVolPct || this.castVolBusy) {
+      return;
+    }
+    this.lastCastVolPct = pct;
+    this.castVolBusy = true;
+    this.session.setVolume(pct).then(() => {
+      this.castVolBusy = false;
+      const latest: number = Math.max(0, Math.min(100, Math.round(host.volumeIndex / max * 100)));
+      if (latest !== this.lastCastVolPct) {
+        this.pushCastVolume();
+      }
+    }).catch((err: Object) => {
+      this.castVolBusy = false;
+      console.info(`[PlayerCastController] cast volume skip: ${JSON.stringify(err)}`);
+    });
+  }
+
+  private onCastState(): void {
+    const host: PlayerCastHost | null = this.host;
+    if (!host) {
+      return;
+    }
+    host.state.currentTime = this.session.positionSec;
+    if (this.session.durationSec > 0 || this.session.phase === CastPhase.LAUNCHING) {
+      host.state.duration = this.session.durationSec;
+    }
+    host.syncFromState();
+    host.onCastUi();
+    host.state.emitProgress(host.onProgress, false);
+    if (this.session.needRelTimeToast && !this.relTimeToasted) {
+      this.session.needRelTimeToast = false;
+      this.relTimeToasted = true;
+      host.toast('设备不支持进度同步');
+    }
+  }
+
+  private parkPlayerForCast(): void {
+    const host: PlayerCastHost | null = this.host;
+    if (!host) {
+      return;
+    }
+    host.watcher.clearOpenWatch();
+    host.watcher.clearSeekWatch();
+    host.watcher.clearHide();
+    host.state.bootGen += 1;
+    host.state.playerOn = false;
+    host.state.errorText = '';
+    host.state.opening = false;
+    host.state.stalled = false;
+    host.state.playRequested = false;
+    host.state.isPlaying = false;
+    host.state.ready = false;
+    host.state.seeking = false;
+    host.playerAv.release();
+    host.syncFromState();
+    host.syncKeepScreen();
+    host.pulseHud();
+  }
+
+  private resumePlayerAfterCast(resumeAt: number, resumePlay: boolean = true): void {
+    const host: PlayerCastHost | null = this.host;
+    if (!host) {
+      return;
+    }
+    const t: number = Math.max(0, resumeAt);
+    host.state.currentTime = t;
+    host.state.pendingResumeSec = t;
+    host.state.errorText = '';
+    host.state.completed = false;
+    host.state.stalled = false;
+    host.state.playRequested = resumePlay;
+    host.state.isPlaying = false;
+    host.state.ready = false;
+    host.state.opening = !!host.videoUrl;
+    host.syncFromState();
+    host.pulseHud();
+    host.remountPlayer();
+  }
+
+  private handleCastPlaybackFailed(resumeAt: number): void {
+    if (this.endingCast) {
+      return;
+    }
+    this.endingCast = true;
+    const host: PlayerCastHost | null = this.host;
+    const play: boolean = this.wasPlaying;
+    const pos: number = Math.max(resumeAt, this.startSec, host ? host.state.currentTime : 0);
+    this.clearCastLocal();
+    if (host) {
+      host.closeCastDialog();
+      this.resumePlayerAfterCast(pos, play);
+      host.toast('投屏失败，已回到手机');
+      host.pulseHud();
+    }
+    this.endingCast = false;
+  }
+
+  private handleCastDisconnected(resumeAt: number): void {
+    if (this.endingCast) {
+      return;
+    }
+    this.endingCast = true;
+    const host: PlayerCastHost | null = this.host;
+    this.clearCastLocal();
+    if (host) {
+      host.closeCastDialog();
+      this.resumePlayerAfterCast(resumeAt, this.wasPlaying);
+      host.toast('电视已停止投屏');
+      host.pulseHud();
+    }
+    this.endingCast = false;
+  }
+
+  private finishCastCompleted(): void {
+    const host: PlayerCastHost | null = this.host;
+    const pos: number = this.session.positionSec;
+    const dur: number = this.session.durationSec;
+    this.session.clearLocal();
+    this.clearCastLocal();
+    if (!host) {
+      return;
+    }
+    host.closeCastDialog();
+    host.state.currentTime = pos > 0 ? pos : dur;
+    if (dur > 0) {
+      host.state.duration = dur;
+    }
+    host.state.completed = true;
+    host.state.playRequested = false;
+    host.state.isPlaying = false;
+    host.state.errorText = '';
+    host.state.opening = false;
+    host.state.stalled = false;
+    host.state.pendingResumeSec = host.state.currentTime;
+    host.syncFromState();
+    host.remountPlayer();
+    host.pulseHud();
+  }
+
+  private recastCurrentUrl(): void {
+    const host: PlayerCastHost | null = this.host;
+    const device: DlnaDevice | null = this.session.device || this.device;
+    if (!host || !device) {
+      this.failRecast();
+      return;
+    }
+    this.session.replaceUri(host.videoUrl, host.title || 'EcoHub', 0).then(() => {
+      console.info('[PlayerCastController] recast ok');
+    }).catch((err: Object) => {
+      console.error(`[PlayerCastController] recast fail: ${JSON.stringify(err)}`);
+      this.failRecast();
+    });
+  }
+
+  private failRecast(): void {
+    const host: PlayerCastHost | null = this.host;
+    this.session.clearLocal();
+    this.clearCastLocal();
+    if (!host) {
+      return;
+    }
+    host.toast('续投失败，已在手机播放');
+    host.state.completed = false;
+    host.state.playRequested = true;
+    host.syncFromState();
+    host.remountPlayer();
+    host.pulseHud();
+  }
+
+  private clearCastLocal(): void {
+    this.device = null;
+    this.deviceName = '';
+    this.connectedUsn = '';
+    this.lastCastVolPct = -1;
+    this.castVolBusy = false;
+    this.relTimeToasted = false;
+    this.keepCastForNext = false;
+    if (this.session.active) {
+      this.session.clearLocal();
+    }
+    if (this.host) {
+      this.host.onCastUi();
+    }
+  }
+
+}

--- a/entry/src/main/ets/components/PlayerCastHud.ets
+++ b/entry/src/main/ets/components/PlayerCastHud.ets
@@ -1,0 +1,489 @@
+import { AppTheme } from '../common/constants/AppTheme';
+import { CastSession } from '../common/utils/CastSession';
+import { DlnaClient } from '../common/utils/DlnaClient';
+import { DlnaDevice, DlnaPositionInfo } from '../common/utils/DlnaTypes';
+import { FormatUtil } from '../common/utils/FormatUtil';
+import { peekCastStartSec } from './PlayerCastSheet';
+import { PlayerIconBtn } from './PlayerControl';
+
+@Component
+export struct PlayerCastHud {
+  @Prop deviceName: string = '';
+  @Prop seedDuration: number = 0;
+  seedDevice: DlnaDevice | null = null;
+  castSession: CastSession | null = null;
+  onStopped: (positionSec: number) => void = (_positionSec: number) => {};
+  onFailed: (positionSec: number) => void = (_positionSec: number) => {};
+  onProgress: (positionSec: number, durationSec: number) => void = (_p: number, _d: number) => {};
+
+  @State private castPosition: number = 0;
+  @State private castDuration: number = 0;
+  @State private transportState: string = '';
+  @State private scrubbing: boolean = false;
+  @State private stopping: boolean = false;
+  @State private transportBusy: boolean = false;
+  private transportHoldUntil: number = 0;
+
+  private client: DlnaClient = new DlnaClient();
+  private pollToken: number = 0;
+  private pollTimer: number = -1;
+  private seekWarned: boolean = false;
+  private positionFailCount: number = 0;
+  private pendingStartSec: number = -1;
+  private startSeekTries: number = 0;
+  private startSeeking: boolean = false;
+  private startAtMs: number = 0;
+  private playbackConfirmed: boolean = false;
+  private failNotified: boolean = false;
+  private originMs: number = 0;
+  private stoppedTicks: number = 0;
+  private logTicks: number = 0;
+
+  private static readonly CONFIRM_TIMEOUT_MS: number = 12000;
+  private static readonly STOPPED_FAIL_WAIT_MS: number = 8000;
+  private static readonly STOPPED_FAIL_TICKS: number = 5;
+
+  aboutToAppear(): void {
+    this.startAtMs = Date.now();
+    const sessionDur: number = this.castSession ? this.castSession.durationSec : 0;
+    this.castDuration = Math.max(sessionDur, this.seedDuration);
+    if (this.castSession) {
+      this.castSession.stopPoll();
+      const start: number = Math.max(this.castSession.positionSec, peekCastStartSec());
+      this.castPosition = start;
+      if (start >= 2) {
+        this.pendingStartSec = start;
+      }
+      if (this.castDuration > 0 && this.castSession.durationSec <= 0) {
+        this.castSession.durationSec = this.castDuration;
+      }
+      console.info(`[PlayerCastHud] pendingStart=${this.pendingStartSec} dur=${this.castDuration}`);
+    }
+    this.startPoll();
+  }
+
+  aboutToDisappear(): void {
+    this.stopPoll();
+    if (this.castSession && this.castSession.active) {
+      this.castSession.startPoll(2000);
+    }
+  }
+
+  private device(): DlnaDevice | null {
+    if (this.seedDevice && this.seedDevice.controlURL) {
+      return this.seedDevice;
+    }
+    if (this.castSession && this.castSession.device) {
+      return this.castSession.device;
+    }
+    return null;
+  }
+
+  private stateLabel(): string {
+    if (!this.playbackConfirmed) {
+      return '正在连接…';
+    }
+    const s: string = (this.transportState || '').toUpperCase();
+    if (s === 'PLAYING') { return '播放中'; }
+    if (s === 'PAUSED_PLAYBACK') { return '已暂停'; }
+    if (s === 'STOPPED') { return '已停止'; }
+    if (s === 'TRANSITIONING') { return '缓冲中'; }
+    return '正在投屏';
+  }
+
+  private toast(msg: string): void {
+    try { this.getUIContext().getPromptAction().showToast({ message: msg }); } catch (_e) {}
+  }
+
+  private startPoll(): void {
+    this.stopPoll();
+    this.pollToken += 1;
+    const token: number = this.pollToken;
+    this.tickOnce(token);
+    this.pollTimer = setInterval(() => {
+      this.tickOnce(token);
+    }, 1000) as number;
+  }
+
+  private stopPoll(): void {
+    this.pollToken += 1;
+    if (this.pollTimer >= 0) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = -1;
+    }
+  }
+
+  private async tickOnce(token: number): Promise<void> {
+    if (token !== this.pollToken || this.failNotified) {
+      return;
+    }
+    const device: DlnaDevice | null = this.device();
+    if (!device || !device.controlURL) {
+      return;
+    }
+    let positionOk: boolean = false;
+    let transportOk: boolean = false;
+    let tvPos: number = 0;
+    let tvDur: number = this.castDuration;
+    let tvReportedDur: number = 0;
+    let relRaw: string = '';
+    let durRaw: string = '';
+    try {
+      const info: DlnaPositionInfo = await this.client.getPositionInfo(device);
+      if (token !== this.pollToken) {
+        return;
+      }
+      positionOk = true;
+      this.positionFailCount = 0;
+      tvPos = info.positionSec;
+      relRaw = info.relTime;
+      durRaw = info.trackDuration;
+      if (info.durationSec > 0) {
+        tvDur = info.durationSec;
+        tvReportedDur = info.durationSec;
+      }
+      this.applyPosition(info, tvDur);
+    } catch (err) {
+      this.positionFailCount += 1;
+      console.error(`[PlayerCastHud] GetPositionInfo fail: ${JSON.stringify(err)}`);
+    }
+
+    try {
+      const state: string = await this.client.getTransportInfo(device);
+      if (token !== this.pollToken) {
+        return;
+      }
+      transportOk = true;
+      if (!this.transportBusy && Date.now() >= this.transportHoldUntil) {
+        this.transportState = state;
+      }
+      if (this.castSession && this.castSession.noteTransportState(state)) {
+        this.stopPoll();
+        return;
+      }
+    } catch (_e) {
+    }
+
+    if (token !== this.pollToken) {
+      return;
+    }
+    if (this.logTicks < 6) {
+      this.logTicks += 1;
+      console.info(`[PlayerCastHud] tick RelTime=${relRaw} TrackDuration=${durRaw} ` +
+        `tv=${tvPos}/${tvDur} state=${this.transportState} confirmed=${this.playbackConfirmed}`);
+    }
+    if (!positionOk && !transportOk && this.castSession) {
+      if (this.castSession.notePollFailure()) {
+        this.stopPoll();
+        return;
+      }
+    } else if (!positionOk && transportOk && this.positionFailCount === 3) {
+      this.toast('设备不支持进度同步');
+    }
+    if (this.judgePlayback(tvPos, tvReportedDur)) {
+      return;
+    }
+    this.applyPendingStart(device, tvPos, tvDur);
+  }
+
+  private applyPosition(info: DlnaPositionInfo, tvDur: number): void {
+    if (this.castDuration <= 0 && this.seedDuration > 0) {
+      this.castDuration = this.seedDuration;
+    }
+    if (this.castSession) {
+      this.castSession.notePollSuccess();
+      this.castSession.positionSec = this.pendingStartSec >= 2 ? this.pendingStartSec : info.positionSec;
+      if (info.durationSec > 0) {
+        this.castSession.durationSec = info.durationSec;
+      } else if (this.castSession.durationSec <= 0 && this.castDuration > 0) {
+        this.castSession.durationSec = this.castDuration;
+      }
+    }
+    if (info.durationSec > 0) {
+      this.castDuration = info.durationSec;
+    }
+    if (this.scrubbing) {
+      this.onProgress(this.castPosition, this.castDuration);
+      return;
+    }
+    const upper: string = (this.transportState || '').toUpperCase();
+    if (this.pendingStartSec >= 2) {
+      if (info.positionSec > 0 && Math.abs(info.positionSec - this.pendingStartSec) <= 8) {
+        this.pendingStartSec = -1;
+        this.castPosition = info.positionSec;
+        this.originMs = Date.now() - info.positionSec * 1000;
+      } else {
+        this.castPosition = this.pendingStartSec;
+      }
+    } else if (info.positionSec > 0) {
+      this.castPosition = info.positionSec;
+      this.originMs = Date.now() - info.positionSec * 1000;
+    } else if (this.playbackConfirmed && upper === 'PLAYING') {
+      if (this.originMs <= 0) {
+        this.originMs = Date.now() - Math.max(0, this.castPosition) * 1000;
+      }
+      let est: number = (Date.now() - this.originMs) / 1000;
+      if (this.castDuration > 1) {
+        est = Math.min(est, this.castDuration);
+      }
+      this.castPosition = Math.max(0, est);
+    }
+    this.onProgress(this.pendingStartSec >= 2 ? this.pendingStartSec : this.castPosition,
+      tvDur > 0 ? tvDur : this.castDuration);
+  }
+
+  private isTransportPlaying(): boolean {
+    const upper: string = (this.transportState || '').toUpperCase();
+    return upper === 'PLAYING' || upper === 'TRANSITIONING' || upper === 'PAUSED_PLAYBACK';
+  }
+
+  /** @returns true if this tick already failed and stopped polling. */
+  private judgePlayback(tvPos: number, tvReportedDur: number): boolean {
+    const upper: string = (this.transportState || '').toUpperCase();
+    if (this.isTransportPlaying() || tvPos > 0 || (tvReportedDur > 1 && upper !== 'STOPPED')) {
+      this.playbackConfirmed = true;
+      this.stoppedTicks = 0;
+      return false;
+    }
+    if (upper === 'ERROR') {
+      this.failCast('ERROR');
+      return true;
+    }
+    const waited: number = Date.now() - this.startAtMs;
+    if (upper === 'STOPPED' || upper === 'NO_MEDIA_PRESENT') {
+      this.stoppedTicks += 1;
+    } else {
+      this.stoppedTicks = 0;
+    }
+    if (!this.playbackConfirmed && this.stoppedTicks >= PlayerCastHud.STOPPED_FAIL_TICKS &&
+      waited >= PlayerCastHud.STOPPED_FAIL_WAIT_MS) {
+      this.failCast(upper || 'STOPPED');
+      return true;
+    }
+    if (!this.playbackConfirmed && waited >= PlayerCastHud.CONFIRM_TIMEOUT_MS) {
+      this.failCast('timeout');
+      return true;
+    }
+    return false;
+  }
+
+  private failCast(reason: string): void {
+    if (this.failNotified || this.stopping) {
+      return;
+    }
+    this.failNotified = true;
+    this.stopPoll();
+    console.info(`[PlayerCastHud] playback fail: ${reason}`);
+    const device: DlnaDevice | null = this.device();
+    const pos: number = this.castPosition > 0 ? this.castPosition :
+      (this.castSession ? this.castSession.positionSec : 0);
+    this.onFailed(pos);
+    if (device) {
+      this.client.stop(device).catch((_e: Object) => {});
+    }
+  }
+
+  private applyPendingStart(device: DlnaDevice, tvPos: number, durationSec: number): void {
+    if (this.pendingStartSec < 2 || this.startSeeking) {
+      return;
+    }
+    if (tvPos > 0 && Math.abs(tvPos - this.pendingStartSec) <= 8) {
+      this.pendingStartSec = -1;
+      return;
+    }
+    if (this.startSeekTries >= 8) {
+      if (!this.seekWarned) {
+        this.seekWarned = true;
+        this.pendingStartSec = -1;
+        this.toast('未能跳到手机进度，可手动拖动');
+      }
+      return;
+    }
+    const upper: string = (this.transportState || '').toUpperCase();
+    const clockReady: boolean = durationSec > 1;
+    const playing: boolean = upper === 'PLAYING' || upper === 'TRANSITIONING' || upper === 'PAUSED_PLAYBACK';
+    const waited: number = Date.now() - this.startAtMs;
+    if (!clockReady && waited < 2500) {
+      return;
+    }
+    if (!playing && waited < 4000) {
+      return;
+    }
+    const target: number = durationSec > 1 ?
+      Math.min(this.pendingStartSec, Math.max(0, durationSec - 1)) : this.pendingStartSec;
+    this.startSeeking = true;
+    this.startSeekTries += 1;
+    console.info(`[PlayerCastHud] resume seek try=${this.startSeekTries} target=${target} ` +
+      `tv=${tvPos} dur=${durationSec} state=${upper}`);
+    this.client.seek(device, target).then(() => {
+      this.startSeeking = false;
+    }).catch((err: Object) => {
+      this.startSeeking = false;
+      console.error(`[PlayerCastHud] resume seek fail: ${JSON.stringify(err)}`);
+      if (this.startSeekTries >= 8 && !this.seekWarned) {
+        this.seekWarned = true;
+        this.pendingStartSec = -1;
+        this.toast('未能跳到手机进度，可手动拖动');
+      }
+    });
+  }
+
+  private isPaused(): boolean {
+    const s: string = (this.transportState || '').toUpperCase();
+    return s === 'PAUSED_PLAYBACK' || s === 'STOPPED';
+  }
+
+  private async togglePause(): Promise<void> {
+    if (this.stopping || this.transportBusy) {
+      return;
+    }
+    const device: DlnaDevice | null = this.device();
+    if (!device || !device.controlURL) {
+      return;
+    }
+    const pause: boolean = !this.isPaused();
+    this.transportBusy = true;
+    this.transportHoldUntil = Date.now() + 2000;
+    this.transportState = pause ? 'PAUSED_PLAYBACK' : 'PLAYING';
+    try {
+      if (pause) {
+        await this.client.pause(device);
+      } else {
+        await this.client.play(device);
+      }
+      if (this.castSession) {
+        this.castSession.transportState = this.transportState;
+      }
+    } catch (err) {
+      console.error(`[PlayerCastHud] pause/play fail: ${JSON.stringify(err)}`);
+      this.toast(pause ? '设备不支持暂停' : '设备不支持继续播放');
+    } finally {
+      this.transportBusy = false;
+    }
+  }
+
+  private async stopCast(): Promise<void> {
+    if (this.stopping) {
+      return;
+    }
+    const device: DlnaDevice | null = this.device();
+    this.stopping = true;
+    this.stopPoll();
+    try {
+      if (device) {
+        await this.client.stop(device);
+      }
+    } catch (err) {
+      console.error(`[PlayerCastHud] stop failed: ${JSON.stringify(err)}`);
+    } finally {
+      this.stopping = false;
+      const pos: number = this.castPosition > 0 ? this.castPosition :
+        (this.castSession ? this.castSession.positionSec : 0);
+      this.onStopped(pos);
+      this.toast('已停止投屏');
+    }
+  }
+
+  private async seekTo(sec: number): Promise<void> {
+    const device: DlnaDevice | null = this.device();
+    if (!device) {
+      return;
+    }
+    this.pendingStartSec = -1;
+    const target: number = Math.max(0, this.castDuration > 0 ? Math.min(sec, this.castDuration) : sec);
+    try {
+      await this.client.seek(device, target);
+      this.castPosition = target;
+      if (this.castSession) {
+        this.castSession.positionSec = target;
+      }
+    } catch (err) {
+      console.error(`[PlayerCastHud] Seek fail: ${JSON.stringify(err)}`);
+      if (!this.seekWarned) {
+        this.seekWarned = true;
+        this.toast('设备不支持进度拖动');
+      }
+    }
+  }
+
+  build() {
+    Column() {
+      Text(`投屏至 ${this.deviceName || '电视'}`)
+        .fontSize(13)
+        .fontWeight(FontWeight.Medium)
+        .fontColor(AppTheme.TEXT_PRIMARY)
+        .maxLines(1)
+        .textOverflow({ overflow: TextOverflow.Ellipsis })
+        .textAlign(TextAlign.Center)
+        .width('100%')
+      Text(this.stateLabel())
+        .fontSize(11)
+        .fontColor(AppTheme.TEXT_MUTED)
+        .margin({ top: 2 })
+
+      Row() {
+        Text(FormatUtil.duration(this.castPosition))
+          .fontSize(11)
+          .fontColor(AppTheme.TEXT_MUTED)
+        Slider({
+          value: this.castPosition,
+          min: 0,
+          max: this.castDuration > 0 ? this.castDuration : 1,
+          step: 1,
+          style: SliderStyle.OutSet
+        })
+          .layoutWeight(1)
+          .height(16)
+          .trackThickness(2)
+          .blockSize({ width: 10, height: 10 })
+          .blockColor('#FFFFFF')
+          .trackColor('rgba(255,255,255,0.28)')
+          .selectedColor(AppTheme.ACCENT)
+          .margin({ left: 6, right: 6 })
+          .enabled(this.castDuration > 0)
+          .onChange((value: number, mode: SliderChangeMode) => {
+            this.castPosition = value;
+            if (mode === SliderChangeMode.Begin || mode === SliderChangeMode.Moving) {
+              this.scrubbing = true;
+            } else if (mode === SliderChangeMode.End || mode === SliderChangeMode.Click) {
+              this.scrubbing = false;
+              this.seekTo(value);
+            }
+          })
+        Text(FormatUtil.duration(this.castDuration))
+          .fontSize(11)
+          .fontColor(AppTheme.TEXT_MUTED)
+      }
+      .width('100%')
+      .margin({ top: 10 })
+      .alignItems(VerticalAlign.Center)
+
+      PlayerIconBtn({
+        src: this.isPaused() ? $r('sys.symbol.play_fill') : $r('sys.symbol.pause_fill'),
+        iconSize: 22,
+        boxSize: 44,
+        circle: true,
+        prominent: true,
+        canTap: !this.transportBusy,
+        onTap: () => this.togglePause()
+      })
+        .margin({ top: 8 })
+    }
+    .width(268)
+    .padding({
+      left: AppTheme.SPACE_LG,
+      right: AppTheme.SPACE_LG,
+      top: AppTheme.SPACE_MD,
+      bottom: AppTheme.SPACE_MD
+    })
+    .alignItems(HorizontalAlign.Center)
+    .backgroundColor('rgba(255,255,255,0.08)')
+    .backgroundBlurStyle(BlurStyle.COMPONENT_THICK, {
+      colorMode: ThemeColorMode.DARK,
+      adaptiveColor: AdaptiveColor.DEFAULT
+    })
+    .borderRadius(AppTheme.RADIUS_LG)
+    .clip(true)
+    .border({ width: 1, color: 'rgba(255,255,255,0.18)' })
+  }
+}

--- a/entry/src/main/ets/components/PlayerCastHud.ets
+++ b/entry/src/main/ets/components/PlayerCastHud.ets
@@ -1,358 +1,86 @@
 import { AppTheme } from '../common/constants/AppTheme';
 import { CastSession } from '../common/utils/CastSession';
-import { DlnaClient } from '../common/utils/DlnaClient';
-import { DlnaDevice, DlnaPositionInfo } from '../common/utils/DlnaTypes';
+import { CastPhase } from '../common/utils/DlnaTypes';
 import { FormatUtil } from '../common/utils/FormatUtil';
-import { peekCastStartSec } from './PlayerCastSheet';
 import { PlayerIconBtn } from './PlayerControl';
 
 @Component
 export struct PlayerCastHud {
   @Prop deviceName: string = '';
-  @Prop seedDuration: number = 0;
-  seedDevice: DlnaDevice | null = null;
+  @Prop positionSec: number = 0;
+  @Prop durationSec: number = 0;
+  @Prop phase: string = '';
+  @Prop transportState: string = '';
   castSession: CastSession | null = null;
-  onStopped: (positionSec: number) => void = (_positionSec: number) => {};
-  onFailed: (positionSec: number) => void = (_positionSec: number) => {};
-  onProgress: (positionSec: number, durationSec: number) => void = (_p: number, _d: number) => {};
 
-  @State private castPosition: number = 0;
-  @State private castDuration: number = 0;
-  @State private transportState: string = '';
+  @State private scrubPos: number = 0;
   @State private scrubbing: boolean = false;
-  @State private stopping: boolean = false;
   @State private transportBusy: boolean = false;
-  private transportHoldUntil: number = 0;
-
-  private client: DlnaClient = new DlnaClient();
-  private pollToken: number = 0;
-  private pollTimer: number = -1;
   private seekWarned: boolean = false;
-  private positionFailCount: number = 0;
-  private pendingStartSec: number = -1;
-  private startSeekTries: number = 0;
-  private startSeeking: boolean = false;
-  private startAtMs: number = 0;
-  private playbackConfirmed: boolean = false;
-  private failNotified: boolean = false;
-  private originMs: number = 0;
-  private stoppedTicks: number = 0;
-  private logTicks: number = 0;
-
-  private static readonly CONFIRM_TIMEOUT_MS: number = 12000;
-  private static readonly STOPPED_FAIL_WAIT_MS: number = 8000;
-  private static readonly STOPPED_FAIL_TICKS: number = 5;
 
   aboutToAppear(): void {
-    this.startAtMs = Date.now();
-    const sessionDur: number = this.castSession ? this.castSession.durationSec : 0;
-    this.castDuration = Math.max(sessionDur, this.seedDuration);
+    this.scrubPos = this.positionSec;
     if (this.castSession) {
-      this.castSession.stopPoll();
-      const start: number = Math.max(this.castSession.positionSec, peekCastStartSec());
-      this.castPosition = start;
-      if (start >= 2) {
-        this.pendingStartSec = start;
-      }
-      if (this.castDuration > 0 && this.castSession.durationSec <= 0) {
-        this.castSession.durationSec = this.castDuration;
-      }
-      console.info(`[PlayerCastHud] pendingStart=${this.pendingStartSec} dur=${this.castDuration}`);
+      this.castSession.setHudPolling(true);
     }
-    this.startPoll();
   }
 
   aboutToDisappear(): void {
-    this.stopPoll();
-    if (this.castSession && this.castSession.active) {
-      this.castSession.startPoll(2000);
+    if (this.castSession) {
+      this.castSession.setHudPolling(false);
     }
   }
 
-  private device(): DlnaDevice | null {
-    if (this.seedDevice && this.seedDevice.controlURL) {
-      return this.seedDevice;
-    }
-    if (this.castSession && this.castSession.device) {
-      return this.castSession.device;
-    }
-    return null;
+  private displayPos(): number {
+    return this.scrubbing ? this.scrubPos : this.positionSec;
   }
 
   private stateLabel(): string {
-    if (!this.playbackConfirmed) {
+    const s: string = (this.transportState || '').toUpperCase();
+    if (s === 'TRANSITIONING' &&
+      (this.phase === CastPhase.LAUNCHING || this.phase === CastPhase.PLAYING)) {
+      return '缓冲中';
+    }
+    if (this.phase === CastPhase.LAUNCHING) {
       return '正在连接…';
     }
-    const s: string = (this.transportState || '').toUpperCase();
-    if (s === 'PLAYING') { return '播放中'; }
-    if (s === 'PAUSED_PLAYBACK') { return '已暂停'; }
-    if (s === 'STOPPED') { return '已停止'; }
-    if (s === 'TRANSITIONING') { return '缓冲中'; }
+    if (this.phase === CastPhase.PLAYING) {
+      return '播放中';
+    }
+    if (this.phase === CastPhase.PAUSED) {
+      return '已暂停';
+    }
     return '正在投屏';
   }
 
+  private isPaused(): boolean {
+    return this.phase === CastPhase.PAUSED ||
+      (this.transportState || '').toUpperCase() === 'PAUSED_PLAYBACK';
+  }
+
+  private canToggle(): boolean {
+    return !this.transportBusy &&
+      (this.phase === CastPhase.PLAYING || this.phase === CastPhase.PAUSED);
+  }
+
   private toast(msg: string): void {
-    try { this.getUIContext().getPromptAction().showToast({ message: msg }); } catch (_e) {}
-  }
-
-  private startPoll(): void {
-    this.stopPoll();
-    this.pollToken += 1;
-    const token: number = this.pollToken;
-    this.tickOnce(token);
-    this.pollTimer = setInterval(() => {
-      this.tickOnce(token);
-    }, 1000) as number;
-  }
-
-  private stopPoll(): void {
-    this.pollToken += 1;
-    if (this.pollTimer >= 0) {
-      clearInterval(this.pollTimer);
-      this.pollTimer = -1;
-    }
-  }
-
-  private async tickOnce(token: number): Promise<void> {
-    if (token !== this.pollToken || this.failNotified) {
-      return;
-    }
-    const device: DlnaDevice | null = this.device();
-    if (!device || !device.controlURL) {
-      return;
-    }
-    let positionOk: boolean = false;
-    let transportOk: boolean = false;
-    let tvPos: number = 0;
-    let tvDur: number = this.castDuration;
-    let tvReportedDur: number = 0;
-    let relRaw: string = '';
-    let durRaw: string = '';
     try {
-      const info: DlnaPositionInfo = await this.client.getPositionInfo(device);
-      if (token !== this.pollToken) {
-        return;
-      }
-      positionOk = true;
-      this.positionFailCount = 0;
-      tvPos = info.positionSec;
-      relRaw = info.relTime;
-      durRaw = info.trackDuration;
-      if (info.durationSec > 0) {
-        tvDur = info.durationSec;
-        tvReportedDur = info.durationSec;
-      }
-      this.applyPosition(info, tvDur);
-    } catch (err) {
-      this.positionFailCount += 1;
-      console.error(`[PlayerCastHud] GetPositionInfo fail: ${JSON.stringify(err)}`);
-    }
-
-    try {
-      const state: string = await this.client.getTransportInfo(device);
-      if (token !== this.pollToken) {
-        return;
-      }
-      transportOk = true;
-      if (!this.transportBusy && Date.now() >= this.transportHoldUntil) {
-        this.transportState = state;
-      }
-      if (this.castSession && this.castSession.noteTransportState(state)) {
-        this.stopPoll();
-        return;
-      }
+      this.getUIContext().getPromptAction().showToast({ message: msg });
     } catch (_e) {
     }
-
-    if (token !== this.pollToken) {
-      return;
-    }
-    if (this.logTicks < 6) {
-      this.logTicks += 1;
-      console.info(`[PlayerCastHud] tick RelTime=${relRaw} TrackDuration=${durRaw} ` +
-        `tv=${tvPos}/${tvDur} state=${this.transportState} confirmed=${this.playbackConfirmed}`);
-    }
-    if (!positionOk && !transportOk && this.castSession) {
-      if (this.castSession.notePollFailure()) {
-        this.stopPoll();
-        return;
-      }
-    } else if (!positionOk && transportOk && this.positionFailCount === 3) {
-      this.toast('设备不支持进度同步');
-    }
-    if (this.judgePlayback(tvPos, tvReportedDur)) {
-      return;
-    }
-    this.applyPendingStart(device, tvPos, tvDur);
-  }
-
-  private applyPosition(info: DlnaPositionInfo, tvDur: number): void {
-    if (this.castDuration <= 0 && this.seedDuration > 0) {
-      this.castDuration = this.seedDuration;
-    }
-    if (this.castSession) {
-      this.castSession.notePollSuccess();
-      this.castSession.positionSec = this.pendingStartSec >= 2 ? this.pendingStartSec : info.positionSec;
-      if (info.durationSec > 0) {
-        this.castSession.durationSec = info.durationSec;
-      } else if (this.castSession.durationSec <= 0 && this.castDuration > 0) {
-        this.castSession.durationSec = this.castDuration;
-      }
-    }
-    if (info.durationSec > 0) {
-      this.castDuration = info.durationSec;
-    }
-    if (this.scrubbing) {
-      this.onProgress(this.castPosition, this.castDuration);
-      return;
-    }
-    const upper: string = (this.transportState || '').toUpperCase();
-    if (this.pendingStartSec >= 2) {
-      if (info.positionSec > 0 && Math.abs(info.positionSec - this.pendingStartSec) <= 8) {
-        this.pendingStartSec = -1;
-        this.castPosition = info.positionSec;
-        this.originMs = Date.now() - info.positionSec * 1000;
-      } else {
-        this.castPosition = this.pendingStartSec;
-      }
-    } else if (info.positionSec > 0) {
-      this.castPosition = info.positionSec;
-      this.originMs = Date.now() - info.positionSec * 1000;
-    } else if (this.playbackConfirmed && upper === 'PLAYING') {
-      if (this.originMs <= 0) {
-        this.originMs = Date.now() - Math.max(0, this.castPosition) * 1000;
-      }
-      let est: number = (Date.now() - this.originMs) / 1000;
-      if (this.castDuration > 1) {
-        est = Math.min(est, this.castDuration);
-      }
-      this.castPosition = Math.max(0, est);
-    }
-    this.onProgress(this.pendingStartSec >= 2 ? this.pendingStartSec : this.castPosition,
-      tvDur > 0 ? tvDur : this.castDuration);
-  }
-
-  private isTransportPlaying(): boolean {
-    const upper: string = (this.transportState || '').toUpperCase();
-    return upper === 'PLAYING' || upper === 'TRANSITIONING' || upper === 'PAUSED_PLAYBACK';
-  }
-
-  /** @returns true if this tick already failed and stopped polling. */
-  private judgePlayback(tvPos: number, tvReportedDur: number): boolean {
-    const upper: string = (this.transportState || '').toUpperCase();
-    if (this.isTransportPlaying() || tvPos > 0 || (tvReportedDur > 1 && upper !== 'STOPPED')) {
-      this.playbackConfirmed = true;
-      this.stoppedTicks = 0;
-      return false;
-    }
-    if (upper === 'ERROR') {
-      this.failCast('ERROR');
-      return true;
-    }
-    const waited: number = Date.now() - this.startAtMs;
-    if (upper === 'STOPPED' || upper === 'NO_MEDIA_PRESENT') {
-      this.stoppedTicks += 1;
-    } else {
-      this.stoppedTicks = 0;
-    }
-    if (!this.playbackConfirmed && this.stoppedTicks >= PlayerCastHud.STOPPED_FAIL_TICKS &&
-      waited >= PlayerCastHud.STOPPED_FAIL_WAIT_MS) {
-      this.failCast(upper || 'STOPPED');
-      return true;
-    }
-    if (!this.playbackConfirmed && waited >= PlayerCastHud.CONFIRM_TIMEOUT_MS) {
-      this.failCast('timeout');
-      return true;
-    }
-    return false;
-  }
-
-  private failCast(reason: string): void {
-    if (this.failNotified || this.stopping) {
-      return;
-    }
-    this.failNotified = true;
-    this.stopPoll();
-    console.info(`[PlayerCastHud] playback fail: ${reason}`);
-    const device: DlnaDevice | null = this.device();
-    const pos: number = this.castPosition > 0 ? this.castPosition :
-      (this.castSession ? this.castSession.positionSec : 0);
-    this.onFailed(pos);
-    if (device) {
-      this.client.stop(device).catch((_e: Object) => {});
-    }
-  }
-
-  private applyPendingStart(device: DlnaDevice, tvPos: number, durationSec: number): void {
-    if (this.pendingStartSec < 2 || this.startSeeking) {
-      return;
-    }
-    if (tvPos > 0 && Math.abs(tvPos - this.pendingStartSec) <= 8) {
-      this.pendingStartSec = -1;
-      return;
-    }
-    if (this.startSeekTries >= 8) {
-      if (!this.seekWarned) {
-        this.seekWarned = true;
-        this.pendingStartSec = -1;
-        this.toast('未能跳到手机进度，可手动拖动');
-      }
-      return;
-    }
-    const upper: string = (this.transportState || '').toUpperCase();
-    const clockReady: boolean = durationSec > 1;
-    const playing: boolean = upper === 'PLAYING' || upper === 'TRANSITIONING' || upper === 'PAUSED_PLAYBACK';
-    const waited: number = Date.now() - this.startAtMs;
-    if (!clockReady && waited < 2500) {
-      return;
-    }
-    if (!playing && waited < 4000) {
-      return;
-    }
-    const target: number = durationSec > 1 ?
-      Math.min(this.pendingStartSec, Math.max(0, durationSec - 1)) : this.pendingStartSec;
-    this.startSeeking = true;
-    this.startSeekTries += 1;
-    console.info(`[PlayerCastHud] resume seek try=${this.startSeekTries} target=${target} ` +
-      `tv=${tvPos} dur=${durationSec} state=${upper}`);
-    this.client.seek(device, target).then(() => {
-      this.startSeeking = false;
-    }).catch((err: Object) => {
-      this.startSeeking = false;
-      console.error(`[PlayerCastHud] resume seek fail: ${JSON.stringify(err)}`);
-      if (this.startSeekTries >= 8 && !this.seekWarned) {
-        this.seekWarned = true;
-        this.pendingStartSec = -1;
-        this.toast('未能跳到手机进度，可手动拖动');
-      }
-    });
-  }
-
-  private isPaused(): boolean {
-    const s: string = (this.transportState || '').toUpperCase();
-    return s === 'PAUSED_PLAYBACK' || s === 'STOPPED';
   }
 
   private async togglePause(): Promise<void> {
-    if (this.stopping || this.transportBusy) {
-      return;
-    }
-    const device: DlnaDevice | null = this.device();
-    if (!device || !device.controlURL) {
+    if (!this.canToggle() || !this.castSession) {
       return;
     }
     const pause: boolean = !this.isPaused();
     this.transportBusy = true;
-    this.transportHoldUntil = Date.now() + 2000;
-    this.transportState = pause ? 'PAUSED_PLAYBACK' : 'PLAYING';
     try {
       if (pause) {
-        await this.client.pause(device);
+        await this.castSession.pause();
       } else {
-        await this.client.play(device);
-      }
-      if (this.castSession) {
-        this.castSession.transportState = this.transportState;
+        await this.castSession.play();
       }
     } catch (err) {
       console.error(`[PlayerCastHud] pause/play fail: ${JSON.stringify(err)}`);
@@ -362,41 +90,13 @@ export struct PlayerCastHud {
     }
   }
 
-  private async stopCast(): Promise<void> {
-    if (this.stopping) {
-      return;
-    }
-    const device: DlnaDevice | null = this.device();
-    this.stopping = true;
-    this.stopPoll();
-    try {
-      if (device) {
-        await this.client.stop(device);
-      }
-    } catch (err) {
-      console.error(`[PlayerCastHud] stop failed: ${JSON.stringify(err)}`);
-    } finally {
-      this.stopping = false;
-      const pos: number = this.castPosition > 0 ? this.castPosition :
-        (this.castSession ? this.castSession.positionSec : 0);
-      this.onStopped(pos);
-      this.toast('已停止投屏');
-    }
-  }
-
   private async seekTo(sec: number): Promise<void> {
-    const device: DlnaDevice | null = this.device();
-    if (!device) {
+    if (!this.castSession) {
       return;
     }
-    this.pendingStartSec = -1;
-    const target: number = Math.max(0, this.castDuration > 0 ? Math.min(sec, this.castDuration) : sec);
+    const target: number = Math.max(0, this.durationSec > 0 ? Math.min(sec, this.durationSec) : sec);
     try {
-      await this.client.seek(device, target);
-      this.castPosition = target;
-      if (this.castSession) {
-        this.castSession.positionSec = target;
-      }
+      await this.castSession.seek(target);
     } catch (err) {
       console.error(`[PlayerCastHud] Seek fail: ${JSON.stringify(err)}`);
       if (!this.seekWarned) {
@@ -422,13 +122,13 @@ export struct PlayerCastHud {
         .margin({ top: 2 })
 
       Row() {
-        Text(FormatUtil.duration(this.castPosition))
+        Text(FormatUtil.duration(this.displayPos()))
           .fontSize(11)
           .fontColor(AppTheme.TEXT_MUTED)
         Slider({
-          value: this.castPosition,
+          value: this.displayPos(),
           min: 0,
-          max: this.castDuration > 0 ? this.castDuration : 1,
+          max: this.durationSec > 0 ? this.durationSec : 1,
           step: 1,
           style: SliderStyle.OutSet
         })
@@ -440,9 +140,9 @@ export struct PlayerCastHud {
           .trackColor('rgba(255,255,255,0.28)')
           .selectedColor(AppTheme.ACCENT)
           .margin({ left: 6, right: 6 })
-          .enabled(this.castDuration > 0)
+          .enabled(this.durationSec > 0)
           .onChange((value: number, mode: SliderChangeMode) => {
-            this.castPosition = value;
+            this.scrubPos = value;
             if (mode === SliderChangeMode.Begin || mode === SliderChangeMode.Moving) {
               this.scrubbing = true;
             } else if (mode === SliderChangeMode.End || mode === SliderChangeMode.Click) {
@@ -450,7 +150,7 @@ export struct PlayerCastHud {
               this.seekTo(value);
             }
           })
-        Text(FormatUtil.duration(this.castDuration))
+        Text(FormatUtil.duration(this.durationSec))
           .fontSize(11)
           .fontColor(AppTheme.TEXT_MUTED)
       }
@@ -464,7 +164,7 @@ export struct PlayerCastHud {
         boxSize: 44,
         circle: true,
         prominent: true,
-        canTap: !this.transportBusy,
+        canTap: this.canToggle(),
         onTap: () => this.togglePause()
       })
         .margin({ top: 8 })

--- a/entry/src/main/ets/components/PlayerCastSheet.ets
+++ b/entry/src/main/ets/components/PlayerCastSheet.ets
@@ -1,77 +1,59 @@
 import { AppTheme } from '../common/constants/AppTheme';
-import { CastSession } from '../common/utils/CastSession';
 import { DlnaClient } from '../common/utils/DlnaClient';
-import { DlnaDevice, DlnaPositionInfo, DlnaScanState } from '../common/utils/DlnaTypes';
-import { FormatUtil } from '../common/utils/FormatUtil';
+import { DlnaDevice, DlnaScanState } from '../common/utils/DlnaTypes';
+
+let launchStartSec: number = 0;
+
+export function markCastStartSec(sec: number): void {
+  launchStartSec = Math.max(0, sec);
+  console.info(`[PlayerCastSheet] markCastStartSec=${launchStartSec}`);
+}
+
+export function peekCastStartSec(): number {
+  return launchStartSec;
+}
 
 @CustomDialog
-struct PlayerCastDialog {
+struct PlayerCastPicker {
   controller?: CustomDialogController;
-  @Link devices: DlnaDevice[];
-  @Link scanState: number;
-  @Link errorText: string;
-  @Link connectedUsn: string;
-  @Link casting: boolean;
   mediaUrl: string = '';
   mediaTitle: string = '';
+  startPosition: number = 0;
+  startDuration: number = 0;
+  connectedUsn: string = '';
+  seedDevice: DlnaDevice | null = null;
+  getStartPosition: () => number = () => 0;
   onCasted: (device: DlnaDevice) => void = (_d: DlnaDevice) => {};
-  onStopped: () => void = () => {};
-  onRescan: () => void = () => {};
+  private dismissed: boolean = false;
+
+  @State private devices: DlnaDevice[] = [];
+  @State private scanState: number = DlnaScanState.IDLE;
+  @State private errorText: string = '';
+  @State private casting: boolean = false;
+
+  @StorageLink('SAFE_INSET_LEFT') private leftInset: number = 0;
+  @StorageLink('SAFE_INSET_RIGHT') private rightInset: number = 0;
+  @StorageLink('SAFE_INSET_BOTTOM') private bottomInset: number = 16;
+  @StorageLink('WINDOW_HEIGHT') private windowHeight: number = 640;
+
   private client: DlnaClient = new DlnaClient();
 
-  @State private castPosition: number = 0;
-  @State private castDuration: number = 0;
-  @State private castVolume: number = 50;
-  @State private volumeSupported: boolean = false;
-  @State private transportState: string = '';
-  @State private scrubbing: boolean = false;
-  @State private volumeBusy: boolean = false;
-
-  private pollToken: number = 0;
-  private pollTimer: number = -1;
-  private seekWarned: boolean = false;
-  private volumeWarned: boolean = false;
-  private positionFailCount: number = 0;
-
-  // Seeded from VideoPlayer CastSession so reopen after screen-off shows fresh progress.
-  seedPosition: number = 0;
-  seedDuration: number = 0;
-  seedVolume: number = 50;
-  seedVolumeSupported: boolean = false;
-  /** Shared with VideoPlayer so sheet poll shares remote-disconnect detection. */
-  castSession: CastSession | null = null;
-
   aboutToAppear(): void {
-    if (this.connectedUsn) {
-      if (this.seedDuration > 0 || this.seedPosition > 0) {
-        this.castPosition = this.seedPosition;
-        this.castDuration = this.seedDuration;
-      }
-      if (this.seedVolumeSupported) {
-        this.castVolume = this.seedVolume;
-        this.volumeSupported = true;
-      }
-      this.startPoll();
-      const device: DlnaDevice | null = this.connectedDevice();
-      if (device) {
-        this.loadVolume(device);
-      }
-    }
+    this.dismissed = false;
+    this.startScan();
   }
 
   aboutToDisappear(): void {
-    this.stopPoll();
+    this.dismissed = true;
+    this.client.cancelDiscover();
+  }
+
+  private isLandscape(): boolean {
+    return this.windowHeight > 0 && this.windowHeight < 500;
   }
 
   private statusText(): string {
     if (this.casting) {
-      return '正在投屏…';
-    }
-    if (this.connectedUsn) {
-      const stateHint: string = this.transportLabel();
-      if (stateHint) {
-        return `正在投屏 · ${stateHint}`;
-      }
       return '正在投屏…';
     }
     if (this.scanState === DlnaScanState.SCANNING) {
@@ -86,52 +68,6 @@ struct PlayerCastDialog {
     return `发现 ${this.devices.length} 台设备，点选即可投屏`;
   }
 
-  private transportLabel(): string {
-    const s: string = this.transportState;
-    if (!s) {
-      return '';
-    }
-    if (s === 'PLAYING') {
-      return '播放中';
-    }
-    if (s === 'PAUSED_PLAYBACK') {
-      return '已暂停';
-    }
-    if (s === 'STOPPED') {
-      return '已停止';
-    }
-    if (s === 'TRANSITIONING') {
-      return '缓冲中';
-    }
-    return s;
-  }
-
-  private connectedDevice(): DlnaDevice | null {
-    if (!this.connectedUsn) {
-      return null;
-    }
-    for (let i = 0; i < this.devices.length; i++) {
-      if (this.devices[i].usn === this.connectedUsn) {
-        return this.devices[i];
-      }
-    }
-    return null;
-  }
-
-  private connectedName(): string {
-    const d: DlnaDevice | null = this.connectedDevice();
-    return d ? d.friendlyName : '已连接设备';
-  }
-
-  private connectedHost(): string {
-    const d: DlnaDevice | null = this.connectedDevice();
-    return d ? d.host : '';
-  }
-
-  private castTimeText(): string {
-    return `${FormatUtil.duration(this.castPosition)} / ${FormatUtil.duration(this.castDuration)}`;
-  }
-
   private toast(msg: string): void {
     try {
       this.getUIContext().getPromptAction().showToast({ message: msg });
@@ -139,121 +75,52 @@ struct PlayerCastDialog {
     }
   }
 
-  private resetCastUi(): void {
-    this.castPosition = 0;
-    this.castDuration = 0;
-    this.castVolume = 50;
-    this.volumeSupported = false;
-    this.transportState = '';
-    this.scrubbing = false;
-    this.volumeBusy = false;
-    this.seekWarned = false;
-    this.volumeWarned = false;
-    this.positionFailCount = 0;
+  private startScan(): void {
+    this.client.cancelDiscover();
+    this.scanState = DlnaScanState.SCANNING;
+    this.errorText = '';
+    const keep: DlnaDevice[] = [];
+    if (this.seedDevice && this.connectedUsn) {
+      keep.push(this.seedDevice);
+    }
+    this.devices = keep;
+    this.client.discover((list: DlnaDevice[]) => {
+      this.mergeDevices(list);
+    }).then((list: DlnaDevice[]) => {
+      this.mergeDevices(list);
+      this.scanState = DlnaScanState.DONE;
+    }).catch((err: Object) => {
+      const msg: string = err instanceof Error ? err.message : '搜索失败';
+      this.errorText = msg;
+      this.scanState = DlnaScanState.ERROR;
+    });
   }
 
-  private startPoll(): void {
-    this.stopPoll();
-    this.pollToken += 1;
-    const token: number = this.pollToken;
-    this.tickOnce(token);
-    this.pollTimer = setInterval(() => {
-      this.tickOnce(token);
-    }, 1000) as number;
+  private mergeDevices(list: DlnaDevice[]): void {
+    const map: Map<string, DlnaDevice> = new Map();
+    if (this.seedDevice && this.connectedUsn) {
+      map.set(this.deviceKey(this.seedDevice), this.seedDevice);
+    }
+    for (let i = 0; i < list.length; i++) {
+      const d: DlnaDevice = list[i];
+      if (d.controlURL) {
+        map.set(this.deviceKey(d), d);
+      }
+    }
+    const merged: DlnaDevice[] = [];
+    map.forEach((d: DlnaDevice) => {
+      merged.push(d);
+    });
+    this.devices = merged;
   }
 
-  private stopPoll(): void {
-    this.pollToken += 1;
-    if (this.pollTimer >= 0) {
-      clearInterval(this.pollTimer);
-      this.pollTimer = -1;
+  private deviceKey(d: DlnaDevice): string {
+    const usn: string = d.usn || '';
+    if (usn.indexOf('uuid:') === 0) {
+      const cut: number = usn.indexOf('::');
+      return cut >= 0 ? usn.substring(0, cut) : usn;
     }
-  }
-
-  private async tickOnce(token: number): Promise<void> {
-    if (token !== this.pollToken) {
-      return;
-    }
-    const device: DlnaDevice | null = this.connectedDevice();
-    if (!device || !device.controlURL) {
-      return;
-    }
-    let positionOk: boolean = false;
-    let transportOk: boolean = false;
-    try {
-      const info: DlnaPositionInfo = await this.client.getPositionInfo(device);
-      if (token !== this.pollToken) {
-        return;
-      }
-      positionOk = true;
-      this.positionFailCount = 0;
-      if (this.castSession) {
-        this.castSession.notePollSuccess();
-        this.castSession.positionSec = info.positionSec;
-        if (info.durationSec > 0) {
-          this.castSession.durationSec = info.durationSec;
-        }
-      }
-      if (!this.scrubbing) {
-        this.castPosition = info.positionSec;
-        if (info.durationSec > 0) {
-          this.castDuration = info.durationSec;
-        }
-      }
-    } catch (err) {
-      this.positionFailCount += 1;
-      console.error(`[PlayerCastSheet] GetPositionInfo fail: ${JSON.stringify(err)}`);
-    }
-
-    try {
-      const state: string = await this.client.getTransportInfo(device);
-      if (token !== this.pollToken) {
-        return;
-      }
-      transportOk = true;
-      this.transportState = state;
-      if (this.castSession && this.castSession.noteTransportState(state)) {
-        // Remote disconnect: CastSession already clearLocal + UI callback (no Stop SOAP).
-        this.stopPoll();
-        this.resetCastUi();
-        return;
-      }
-    } catch (_e) {
-      // Optional; many renderers support it but not required.
-    }
-
-    if (token !== this.pollToken) {
-      return;
-    }
-    if (!positionOk && !transportOk && this.castSession) {
-      if (this.castSession.notePollFailure()) {
-        this.stopPoll();
-        this.resetCastUi();
-        return;
-      }
-    } else if (!positionOk && transportOk && this.positionFailCount === 3) {
-      // Transport still alive — renderer likely lacks position sync, not a disconnect.
-      this.toast('设备不支持进度同步');
-    }
-  }
-
-  private async loadVolume(device: DlnaDevice): Promise<void> {
-    if (!device.renderingControlURL) {
-      this.volumeSupported = false;
-      return;
-    }
-    try {
-      const vol: number = await this.client.getVolume(device);
-      this.castVolume = vol;
-      this.volumeSupported = true;
-    } catch (err) {
-      console.error(`[PlayerCastSheet] GetVolume fail: ${JSON.stringify(err)}`);
-      this.volumeSupported = false;
-      if (!this.volumeWarned) {
-        this.volumeWarned = true;
-        this.toast('设备不支持音量控制');
-      }
-    }
+    return d.location || d.controlURL || usn;
   }
 
   private async castTo(device: DlnaDevice): Promise<void> {
@@ -261,17 +128,24 @@ struct PlayerCastDialog {
       this.toast('当前没有可投屏的视频地址');
       return;
     }
+    if (this.casting || this.connectedUsn === device.usn) {
+      return;
+    }
     this.casting = true;
     this.errorText = '';
-    this.stopPoll();
+    this.toast(`正在投屏到 ${device.friendlyName}…`);
     try {
-      await this.client.cast(device, this.mediaUrl, this.mediaTitle || 'EcoHub');
-      this.resetCastUi();
-      this.connectedUsn = device.usn;
+      const startSec: number = Math.max(this.startPosition, launchStartSec);
+      await this.client.cast(device, this.mediaUrl, this.mediaTitle || 'EcoHub',
+        startSec, this.startDuration);
+      if (this.dismissed) {
+        this.client.stop(device).catch((_e: Object) => {});
+        return;
+      }
       this.onCasted(device);
-      this.toast(`已投屏到 ${device.friendlyName}`);
-      this.startPoll();
-      this.loadVolume(device);
+      if (this.controller) {
+        this.controller.close();
+      }
     } catch (err) {
       const msg: string = err instanceof Error ? err.message : '投屏失败';
       this.errorText = msg;
@@ -279,206 +153,6 @@ struct PlayerCastDialog {
     } finally {
       this.casting = false;
     }
-  }
-
-  private async stopCast(): Promise<void> {
-    const device: DlnaDevice | null = this.connectedDevice();
-    this.casting = true;
-    this.stopPoll();
-    try {
-      if (device) {
-        await this.client.stop(device);
-      }
-    } catch (err) {
-      console.error(`[PlayerCastSheet] stop failed: ${JSON.stringify(err)}`);
-    } finally {
-      this.casting = false;
-      this.connectedUsn = '';
-      this.resetCastUi();
-      this.onStopped();
-      this.toast('已停止投屏');
-    }
-  }
-
-  private async seekTo(sec: number): Promise<void> {
-    const device: DlnaDevice | null = this.connectedDevice();
-    if (!device) {
-      return;
-    }
-    const target: number = Math.max(0, this.castDuration > 0 ? Math.min(sec, this.castDuration) : sec);
-    try {
-      await this.client.seek(device, target);
-      this.castPosition = target;
-    } catch (err) {
-      console.error(`[PlayerCastSheet] Seek fail: ${JSON.stringify(err)}`);
-      if (!this.seekWarned) {
-        this.seekWarned = true;
-        this.toast('设备不支持进度拖动');
-      }
-    }
-  }
-
-  private async applyVolume(vol: number): Promise<void> {
-    const device: DlnaDevice | null = this.connectedDevice();
-    if (!device || !this.volumeSupported || this.volumeBusy) {
-      return;
-    }
-    const clamped: number = Math.max(0, Math.min(100, Math.round(vol)));
-    this.castVolume = clamped;
-    this.volumeBusy = true;
-    try {
-      await this.client.setVolume(device, clamped);
-    } catch (err) {
-      console.error(`[PlayerCastSheet] SetVolume fail: ${JSON.stringify(err)}`);
-      if (!this.volumeWarned) {
-        this.volumeWarned = true;
-        this.toast('设备不支持音量控制');
-      }
-      this.volumeSupported = false;
-    } finally {
-      this.volumeBusy = false;
-    }
-  }
-
-  private nudgeVolume(delta: number): void {
-    this.applyVolume(this.castVolume + delta);
-  }
-
-  @Builder
-  connectedControls() {
-    Column() {
-      Row() {
-        Column() {
-          Text(this.connectedName())
-            .fontSize(14)
-            .fontWeight(FontWeight.Medium)
-            .fontColor('#FFFFFF')
-            .maxLines(1)
-            .textOverflow({ overflow: TextOverflow.Ellipsis })
-          Text(this.connectedHost())
-            .fontSize(11)
-            .fontColor(AppTheme.TEXT_MUTED)
-            .margin({ top: 2 })
-        }
-        .alignItems(HorizontalAlign.Start)
-        .layoutWeight(1)
-        Text('停止投屏')
-          .fontSize(13)
-          .fontWeight(FontWeight.Bold)
-          .fontColor('#FFFFFF')
-          .padding({ left: 12, right: 12, top: 8, bottom: 8 })
-          .backgroundColor(AppTheme.DANGER)
-          .borderRadius(10)
-          .onClick(() => {
-            this.stopCast();
-          })
-      }
-      .width('100%')
-
-      // Progress + scrubber
-      Column() {
-        Text(this.castTimeText())
-          .fontSize(12)
-          .fontColor(AppTheme.TEXT_SECONDARY)
-          .width('100%')
-          .margin({ bottom: 4 })
-        Slider({
-          value: this.castPosition,
-          min: 0,
-          max: this.castDuration > 0 ? this.castDuration : 1,
-          step: 1,
-          style: SliderStyle.OutSet
-        })
-          .width('100%')
-          .height(20)
-          .trackThickness(2)
-          .blockSize({ width: 12, height: 12 })
-          .blockColor('#FFFFFF')
-          .trackColor('rgba(255,255,255,0.28)')
-          .selectedColor(AppTheme.ACCENT)
-          .enabled(this.castDuration > 0 && !this.casting)
-          .onChange((value: number, mode: SliderChangeMode) => {
-            this.castPosition = value;
-            if (mode === SliderChangeMode.Begin || mode === SliderChangeMode.Moving) {
-              this.scrubbing = true;
-            } else if (mode === SliderChangeMode.End) {
-              this.scrubbing = false;
-              this.seekTo(value);
-            } else if (mode === SliderChangeMode.Click) {
-              this.scrubbing = false;
-              this.seekTo(value);
-            }
-          })
-      }
-      .width('100%')
-      .margin({ top: 12 })
-
-      // Volume
-      if (this.volumeSupported) {
-        Row() {
-          Text('音量')
-            .fontSize(12)
-            .fontColor(AppTheme.TEXT_SECONDARY)
-            .width(36)
-          Text('−')
-            .fontSize(18)
-            .fontWeight(FontWeight.Bold)
-            .fontColor('#FFFFFF')
-            .width(32)
-            .height(32)
-            .textAlign(TextAlign.Center)
-            .backgroundColor('rgba(255,255,255,0.08)')
-            .borderRadius(8)
-            .onClick(() => this.nudgeVolume(-5))
-          Slider({
-            value: this.castVolume,
-            min: 0,
-            max: 100,
-            step: 1,
-            style: SliderStyle.OutSet
-          })
-            .layoutWeight(1)
-            .height(20)
-            .trackThickness(2)
-            .blockSize({ width: 12, height: 12 })
-            .blockColor('#FFFFFF')
-            .trackColor('rgba(255,255,255,0.28)')
-            .selectedColor(AppTheme.ACCENT)
-            .margin({ left: 6, right: 6 })
-            .enabled(!this.casting && !this.volumeBusy)
-            .onChange((value: number, mode: SliderChangeMode) => {
-              this.castVolume = value;
-              if (mode === SliderChangeMode.End || mode === SliderChangeMode.Click) {
-                this.applyVolume(value);
-              }
-            })
-          Text('+')
-            .fontSize(18)
-            .fontWeight(FontWeight.Bold)
-            .fontColor('#FFFFFF')
-            .width(32)
-            .height(32)
-            .textAlign(TextAlign.Center)
-            .backgroundColor('rgba(255,255,255,0.08)')
-            .borderRadius(8)
-            .onClick(() => this.nudgeVolume(5))
-          Text(`${Math.round(this.castVolume)}`)
-            .fontSize(12)
-            .fontColor(AppTheme.TEXT_MUTED)
-            .width(28)
-            .textAlign(TextAlign.End)
-            .margin({ left: 4 })
-        }
-        .width('100%')
-        .margin({ top: 10 })
-        .alignItems(VerticalAlign.Center)
-      }
-    }
-    .width('100%')
-    .padding(12)
-    .margin({ bottom: 10 })
-    .backgroundColor(AppTheme.ACCENT_SOFT)
-    .borderRadius(12)
   }
 
   build() {
@@ -496,7 +170,7 @@ struct PlayerCastDialog {
           .padding({ left: 8, right: 4, top: 6, bottom: 6 })
           .onClick(() => {
             if (this.scanState !== DlnaScanState.SCANNING && !this.casting) {
-              this.onRescan();
+              this.startScan();
             }
           })
       }
@@ -507,10 +181,6 @@ struct PlayerCastDialog {
         .fontColor('rgba(255,255,255,0.55)')
         .margin({ top: 6, bottom: 12 })
         .width('100%')
-
-      if (this.connectedUsn) {
-        this.connectedControls()
-      }
 
       if (this.scanState === DlnaScanState.SCANNING && this.devices.length === 0) {
         Row() {
@@ -574,20 +244,23 @@ struct PlayerCastDialog {
               .backgroundColor(this.connectedUsn === device.usn ? AppTheme.ACCENT_SOFT : 'rgba(255,255,255,0.06)')
               .borderRadius(12)
               .onClick(() => {
-                if (!this.casting && this.connectedUsn !== device.usn) {
-                  this.castTo(device);
-                }
+                this.castTo(device);
               })
             }
           }, (device: DlnaDevice) => device.usn)
         }
         .width('100%')
-        .constraintSize({ maxHeight: 280 })
+        .constraintSize({ maxHeight: this.isLandscape() ? 140 : 280 })
         .scrollBar(BarState.Off)
       }
     }
     .width('100%')
-    .padding({ left: 16, right: 16, top: 16, bottom: 28 })
+    .padding({
+      left: AppTheme.SPACE_LG + this.leftInset,
+      right: AppTheme.SPACE_LG + this.rightInset,
+      top: 16,
+      bottom: Math.max(24, this.bottomInset + 12)
+    })
     .backgroundColor('#191B20')
     .borderRadius({ topLeft: 20, topRight: 20 })
   }
@@ -598,84 +271,43 @@ export struct PlayerCastSheet {
   @Prop @Watch('onOpenChange') openSeq: number = 0;
   @Prop mediaUrl: string = '';
   @Prop mediaTitle: string = '';
-  /** Linked from VideoPlayer so connection survives dialog close / screen-off. */
-  @Link connectedUsn: string;
-  @Prop @Watch('onSeedDeviceChange') seedDevice: DlnaDevice | null = null;
-  @Prop seedPosition: number = 0;
-  @Prop seedDuration: number = 0;
-  @Prop seedVolume: number = 50;
-  @Prop seedVolumeSupported: boolean = false;
-  /** Shared CastSession for remote-disconnect detection while sheet poll owns the timer. */
-  castSession: CastSession | null = null;
+  @Prop startPosition: number = 0;
+  @Prop startDuration: number = 0;
+  @Prop connectedUsn: string = '';
+  @Prop seedDevice: DlnaDevice | null = null;
+  getStartPosition: () => number = () => 0;
   onCasted: (device: DlnaDevice) => void = (_device: DlnaDevice) => {};
-  onStopped: () => void = () => {};
   onClosed: () => void = () => {};
 
-  @State private devices: DlnaDevice[] = [];
-  @State private scanState: number = DlnaScanState.IDLE;
-  @State private errorText: string = '';
-  @State private casting: boolean = false;
-
   private dialog: CustomDialogController | null = null;
-  private client: DlnaClient = new DlnaClient();
-  private connectedDeviceCache: DlnaDevice | null = null;
-
-  aboutToAppear(): void {
-    this.syncSeedDevice();
-  }
 
   aboutToDisappear(): void {
-    this.client.cancelDiscover();
     this.close();
-  }
-
-  onSeedDeviceChange(): void {
-    this.syncSeedDevice();
-  }
-
-  private syncSeedDevice(): void {
-    if (this.seedDevice) {
-      this.connectedDeviceCache = this.seedDevice;
-    } else if (!this.connectedUsn) {
-      this.connectedDeviceCache = null;
-    }
   }
 
   onOpenChange(): void {
     this.close();
     if (this.openSeq <= 0) {
-      // Dialog dismissed / page hide — do NOT clear connectedUsn or Stop TV.
       return;
     }
-    this.syncSeedDevice();
     this.open();
-    this.startScan();
   }
 
   private open(): void {
     this.dialog = new CustomDialogController({
-      builder: PlayerCastDialog({
-        devices: $devices,
-        scanState: $scanState,
-        errorText: $errorText,
-        connectedUsn: $connectedUsn,
-        casting: $casting,
+      builder: PlayerCastPicker({
         mediaUrl: this.mediaUrl,
         mediaTitle: this.mediaTitle,
-        seedPosition: this.seedPosition,
-        seedDuration: this.seedDuration,
-        seedVolume: this.seedVolume,
-        seedVolumeSupported: this.seedVolumeSupported,
-        castSession: this.castSession,
+        startPosition: this.startPosition,
+        startDuration: this.startDuration,
+        getStartPosition: () => this.getStartPosition ? this.getStartPosition() : this.startPosition,
+        connectedUsn: this.connectedUsn,
+        seedDevice: this.seedDevice,
         onCasted: (device: DlnaDevice) => {
-          this.connectedDeviceCache = device;
           this.onCasted(device);
-        },
-        onStopped: () => {
-          this.connectedDeviceCache = null;
-          this.onStopped();
-        },
-        onRescan: () => this.startScan()
+          this.close();
+          this.onClosed();
+        }
       }),
       autoCancel: true,
       alignment: DialogAlignment.Bottom,
@@ -684,8 +316,6 @@ export struct PlayerCastSheet {
       maskColor: 'rgba(0,0,0,0.52)',
       cancel: () => {
         this.dialog = null;
-        this.client.cancelDiscover();
-        // UI only — connectedUsn / TV session stay alive for screen-off reopen.
         this.onClosed();
       }
     });
@@ -697,46 +327,6 @@ export struct PlayerCastSheet {
       this.dialog.close();
       this.dialog = null;
     }
-  }
-
-  private startScan(): void {
-    this.client.cancelDiscover();
-    this.scanState = DlnaScanState.SCANNING;
-    this.errorText = '';
-    // Keep connected device visible while rescanning.
-    const keep: DlnaDevice[] = [];
-    if (this.connectedDeviceCache && this.connectedUsn) {
-      keep.push(this.connectedDeviceCache);
-    }
-    this.devices = keep;
-    this.client.discover((list: DlnaDevice[]) => {
-      this.mergeDevices(list);
-    }).then((list: DlnaDevice[]) => {
-      this.mergeDevices(list);
-      this.scanState = DlnaScanState.DONE;
-    }).catch((err: Object) => {
-      const msg: string = err instanceof Error ? err.message : '搜索失败';
-      this.errorText = msg;
-      this.scanState = DlnaScanState.ERROR;
-    });
-  }
-
-  private mergeDevices(list: DlnaDevice[]): void {
-    const map: Map<string, DlnaDevice> = new Map();
-    if (this.connectedDeviceCache && this.connectedUsn) {
-      map.set(this.connectedUsn, this.connectedDeviceCache);
-    }
-    for (let i = 0; i < list.length; i++) {
-      const d: DlnaDevice = list[i];
-      if (d.controlURL) {
-        map.set(d.usn, d);
-      }
-    }
-    const merged: DlnaDevice[] = [];
-    map.forEach((d: DlnaDevice) => {
-      merged.push(d);
-    });
-    this.devices = merged;
   }
 
   build() {

--- a/entry/src/main/ets/components/PlayerCastSheet.ets
+++ b/entry/src/main/ets/components/PlayerCastSheet.ets
@@ -1,4 +1,5 @@
 import { AppTheme } from '../common/constants/AppTheme';
+import { CastSession } from '../common/utils/CastSession';
 import { DlnaClient } from '../common/utils/DlnaClient';
 import { DlnaDevice, DlnaPositionInfo, DlnaScanState } from '../common/utils/DlnaTypes';
 import { FormatUtil } from '../common/utils/FormatUtil';
@@ -37,6 +38,8 @@ struct PlayerCastDialog {
   seedDuration: number = 0;
   seedVolume: number = 50;
   seedVolumeSupported: boolean = false;
+  /** Shared with VideoPlayer so sheet poll shares remote-disconnect detection. */
+  castSession: CastSession | null = null;
 
   aboutToAppear(): void {
     if (this.connectedUsn) {
@@ -175,12 +178,22 @@ struct PlayerCastDialog {
     if (!device || !device.controlURL) {
       return;
     }
+    let positionOk: boolean = false;
+    let transportOk: boolean = false;
     try {
       const info: DlnaPositionInfo = await this.client.getPositionInfo(device);
       if (token !== this.pollToken) {
         return;
       }
+      positionOk = true;
       this.positionFailCount = 0;
+      if (this.castSession) {
+        this.castSession.notePollSuccess();
+        this.castSession.positionSec = info.positionSec;
+        if (info.durationSec > 0) {
+          this.castSession.durationSec = info.durationSec;
+        }
+      }
       if (!this.scrubbing) {
         this.castPosition = info.positionSec;
         if (info.durationSec > 0) {
@@ -190,9 +203,6 @@ struct PlayerCastDialog {
     } catch (err) {
       this.positionFailCount += 1;
       console.error(`[PlayerCastSheet] GetPositionInfo fail: ${JSON.stringify(err)}`);
-      if (this.positionFailCount === 3) {
-        this.toast('设备不支持进度同步');
-      }
     }
 
     try {
@@ -200,9 +210,30 @@ struct PlayerCastDialog {
       if (token !== this.pollToken) {
         return;
       }
+      transportOk = true;
       this.transportState = state;
+      if (this.castSession && this.castSession.noteTransportState(state)) {
+        // Remote disconnect: CastSession already clearLocal + UI callback (no Stop SOAP).
+        this.stopPoll();
+        this.resetCastUi();
+        return;
+      }
     } catch (_e) {
       // Optional; many renderers support it but not required.
+    }
+
+    if (token !== this.pollToken) {
+      return;
+    }
+    if (!positionOk && !transportOk && this.castSession) {
+      if (this.castSession.notePollFailure()) {
+        this.stopPoll();
+        this.resetCastUi();
+        return;
+      }
+    } else if (!positionOk && transportOk && this.positionFailCount === 3) {
+      // Transport still alive — renderer likely lacks position sync, not a disconnect.
+      this.toast('设备不支持进度同步');
     }
   }
 
@@ -574,6 +605,8 @@ export struct PlayerCastSheet {
   @Prop seedDuration: number = 0;
   @Prop seedVolume: number = 50;
   @Prop seedVolumeSupported: boolean = false;
+  /** Shared CastSession for remote-disconnect detection while sheet poll owns the timer. */
+  castSession: CastSession | null = null;
   onCasted: (device: DlnaDevice) => void = (_device: DlnaDevice) => {};
   onStopped: () => void = () => {};
   onClosed: () => void = () => {};
@@ -633,6 +666,7 @@ export struct PlayerCastSheet {
         seedDuration: this.seedDuration,
         seedVolume: this.seedVolume,
         seedVolumeSupported: this.seedVolumeSupported,
+        castSession: this.castSession,
         onCasted: (device: DlnaDevice) => {
           this.connectedDeviceCache = device;
           this.onCasted(device);

--- a/entry/src/main/ets/components/PlayerCastSheet.ets
+++ b/entry/src/main/ets/components/PlayerCastSheet.ets
@@ -1,6 +1,6 @@
 import { AppTheme } from '../common/constants/AppTheme';
 import { DlnaClient } from '../common/utils/DlnaClient';
-import { DlnaDevice, DlnaScanState } from '../common/utils/DlnaTypes';
+import { DlnaDevice, DlnaScanState, soapErrorMessage } from '../common/utils/DlnaTypes';
 
 let launchStartSec: number = 0;
 
@@ -147,7 +147,7 @@ struct PlayerCastPicker {
         this.controller.close();
       }
     } catch (err) {
-      const msg: string = err instanceof Error ? err.message : '投屏失败';
+      const msg: string = soapErrorMessage(err);
       this.errorText = msg;
       this.toast(msg);
     } finally {

--- a/entry/src/main/ets/components/PlayerCastSheet.ets
+++ b/entry/src/main/ets/components/PlayerCastSheet.ets
@@ -32,8 +32,22 @@ struct PlayerCastDialog {
   private volumeWarned: boolean = false;
   private positionFailCount: number = 0;
 
+  // Seeded from VideoPlayer CastSession so reopen after screen-off shows fresh progress.
+  seedPosition: number = 0;
+  seedDuration: number = 0;
+  seedVolume: number = 50;
+  seedVolumeSupported: boolean = false;
+
   aboutToAppear(): void {
     if (this.connectedUsn) {
+      if (this.seedDuration > 0 || this.seedPosition > 0) {
+        this.castPosition = this.seedPosition;
+        this.castDuration = this.seedDuration;
+      }
+      if (this.seedVolumeSupported) {
+        this.castVolume = this.seedVolume;
+        this.volumeSupported = true;
+      }
       this.startPoll();
       const device: DlnaDevice | null = this.connectedDevice();
       if (device) {
@@ -553,6 +567,13 @@ export struct PlayerCastSheet {
   @Prop @Watch('onOpenChange') openSeq: number = 0;
   @Prop mediaUrl: string = '';
   @Prop mediaTitle: string = '';
+  /** Linked from VideoPlayer so connection survives dialog close / screen-off. */
+  @Link connectedUsn: string;
+  @Prop @Watch('onSeedDeviceChange') seedDevice: DlnaDevice | null = null;
+  @Prop seedPosition: number = 0;
+  @Prop seedDuration: number = 0;
+  @Prop seedVolume: number = 50;
+  @Prop seedVolumeSupported: boolean = false;
   onCasted: (device: DlnaDevice) => void = (_device: DlnaDevice) => {};
   onStopped: () => void = () => {};
   onClosed: () => void = () => {};
@@ -560,23 +581,40 @@ export struct PlayerCastSheet {
   @State private devices: DlnaDevice[] = [];
   @State private scanState: number = DlnaScanState.IDLE;
   @State private errorText: string = '';
-  @State private connectedUsn: string = '';
   @State private casting: boolean = false;
 
   private dialog: CustomDialogController | null = null;
   private client: DlnaClient = new DlnaClient();
   private connectedDeviceCache: DlnaDevice | null = null;
 
+  aboutToAppear(): void {
+    this.syncSeedDevice();
+  }
+
   aboutToDisappear(): void {
     this.client.cancelDiscover();
     this.close();
   }
 
+  onSeedDeviceChange(): void {
+    this.syncSeedDevice();
+  }
+
+  private syncSeedDevice(): void {
+    if (this.seedDevice) {
+      this.connectedDeviceCache = this.seedDevice;
+    } else if (!this.connectedUsn) {
+      this.connectedDeviceCache = null;
+    }
+  }
+
   onOpenChange(): void {
     this.close();
     if (this.openSeq <= 0) {
+      // Dialog dismissed / page hide — do NOT clear connectedUsn or Stop TV.
       return;
     }
+    this.syncSeedDevice();
     this.open();
     this.startScan();
   }
@@ -591,6 +629,10 @@ export struct PlayerCastSheet {
         casting: $casting,
         mediaUrl: this.mediaUrl,
         mediaTitle: this.mediaTitle,
+        seedPosition: this.seedPosition,
+        seedDuration: this.seedDuration,
+        seedVolume: this.seedVolume,
+        seedVolumeSupported: this.seedVolumeSupported,
         onCasted: (device: DlnaDevice) => {
           this.connectedDeviceCache = device;
           this.onCasted(device);
@@ -609,6 +651,7 @@ export struct PlayerCastSheet {
       cancel: () => {
         this.dialog = null;
         this.client.cancelDiscover();
+        // UI only — connectedUsn / TV session stay alive for screen-off reopen.
         this.onClosed();
       }
     });

--- a/entry/src/main/ets/components/PlayerCastSheet.ets
+++ b/entry/src/main/ets/components/PlayerCastSheet.ets
@@ -45,6 +45,17 @@ struct PlayerCastDialog {
     return null;
   }
 
+
+  private connectedName(): string {
+    const d: DlnaDevice | null = this.connectedDevice();
+    return d ? d.friendlyName : '已连接设备';
+  }
+
+  private connectedHost(): string {
+    const d: DlnaDevice | null = this.connectedDevice();
+    return d ? d.host : '';
+  }
+
   private async castTo(device: DlnaDevice): Promise<void> {
     if (!this.mediaUrl) {
       try {

--- a/entry/src/main/ets/components/PlayerCastSheet.ets
+++ b/entry/src/main/ets/components/PlayerCastSheet.ets
@@ -1,6 +1,7 @@
 import { AppTheme } from '../common/constants/AppTheme';
 import { DlnaClient } from '../common/utils/DlnaClient';
-import { DlnaDevice, DlnaScanState } from '../common/utils/DlnaTypes';
+import { DlnaDevice, DlnaPositionInfo, DlnaScanState } from '../common/utils/DlnaTypes';
+import { FormatUtil } from '../common/utils/FormatUtil';
 
 @CustomDialog
 struct PlayerCastDialog {
@@ -17,8 +18,43 @@ struct PlayerCastDialog {
   onRescan: () => void = () => {};
   private client: DlnaClient = new DlnaClient();
 
+  @State private castPosition: number = 0;
+  @State private castDuration: number = 0;
+  @State private castVolume: number = 50;
+  @State private volumeSupported: boolean = false;
+  @State private transportState: string = '';
+  @State private scrubbing: boolean = false;
+  @State private volumeBusy: boolean = false;
+
+  private pollToken: number = 0;
+  private pollTimer: number = -1;
+  private seekWarned: boolean = false;
+  private volumeWarned: boolean = false;
+  private positionFailCount: number = 0;
+
+  aboutToAppear(): void {
+    if (this.connectedUsn) {
+      this.startPoll();
+      const device: DlnaDevice | null = this.connectedDevice();
+      if (device) {
+        this.loadVolume(device);
+      }
+    }
+  }
+
+  aboutToDisappear(): void {
+    this.stopPoll();
+  }
+
   private statusText(): string {
     if (this.casting) {
+      return '正在投屏…';
+    }
+    if (this.connectedUsn) {
+      const stateHint: string = this.transportLabel();
+      if (stateHint) {
+        return `正在投屏 · ${stateHint}`;
+      }
       return '正在投屏…';
     }
     if (this.scanState === DlnaScanState.SCANNING) {
@@ -33,6 +69,26 @@ struct PlayerCastDialog {
     return `发现 ${this.devices.length} 台设备，点选即可投屏`;
   }
 
+  private transportLabel(): string {
+    const s: string = this.transportState;
+    if (!s) {
+      return '';
+    }
+    if (s === 'PLAYING') {
+      return '播放中';
+    }
+    if (s === 'PAUSED_PLAYBACK') {
+      return '已暂停';
+    }
+    if (s === 'STOPPED') {
+      return '已停止';
+    }
+    if (s === 'TRANSITIONING') {
+      return '缓冲中';
+    }
+    return s;
+  }
+
   private connectedDevice(): DlnaDevice | null {
     if (!this.connectedUsn) {
       return null;
@@ -45,7 +101,6 @@ struct PlayerCastDialog {
     return null;
   }
 
-
   private connectedName(): string {
     const d: DlnaDevice | null = this.connectedDevice();
     return d ? d.friendlyName : '已连接设备';
@@ -56,31 +111,126 @@ struct PlayerCastDialog {
     return d ? d.host : '';
   }
 
+  private castTimeText(): string {
+    return `${FormatUtil.duration(this.castPosition)} / ${FormatUtil.duration(this.castDuration)}`;
+  }
+
+  private toast(msg: string): void {
+    try {
+      this.getUIContext().getPromptAction().showToast({ message: msg });
+    } catch (_e) {
+    }
+  }
+
+  private resetCastUi(): void {
+    this.castPosition = 0;
+    this.castDuration = 0;
+    this.castVolume = 50;
+    this.volumeSupported = false;
+    this.transportState = '';
+    this.scrubbing = false;
+    this.volumeBusy = false;
+    this.seekWarned = false;
+    this.volumeWarned = false;
+    this.positionFailCount = 0;
+  }
+
+  private startPoll(): void {
+    this.stopPoll();
+    this.pollToken += 1;
+    const token: number = this.pollToken;
+    this.tickOnce(token);
+    this.pollTimer = setInterval(() => {
+      this.tickOnce(token);
+    }, 1000) as number;
+  }
+
+  private stopPoll(): void {
+    this.pollToken += 1;
+    if (this.pollTimer >= 0) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = -1;
+    }
+  }
+
+  private async tickOnce(token: number): Promise<void> {
+    if (token !== this.pollToken) {
+      return;
+    }
+    const device: DlnaDevice | null = this.connectedDevice();
+    if (!device || !device.controlURL) {
+      return;
+    }
+    try {
+      const info: DlnaPositionInfo = await this.client.getPositionInfo(device);
+      if (token !== this.pollToken) {
+        return;
+      }
+      this.positionFailCount = 0;
+      if (!this.scrubbing) {
+        this.castPosition = info.positionSec;
+        if (info.durationSec > 0) {
+          this.castDuration = info.durationSec;
+        }
+      }
+    } catch (err) {
+      this.positionFailCount += 1;
+      console.error(`[PlayerCastSheet] GetPositionInfo fail: ${JSON.stringify(err)}`);
+      if (this.positionFailCount === 3) {
+        this.toast('设备不支持进度同步');
+      }
+    }
+
+    try {
+      const state: string = await this.client.getTransportInfo(device);
+      if (token !== this.pollToken) {
+        return;
+      }
+      this.transportState = state;
+    } catch (_e) {
+      // Optional; many renderers support it but not required.
+    }
+  }
+
+  private async loadVolume(device: DlnaDevice): Promise<void> {
+    if (!device.renderingControlURL) {
+      this.volumeSupported = false;
+      return;
+    }
+    try {
+      const vol: number = await this.client.getVolume(device);
+      this.castVolume = vol;
+      this.volumeSupported = true;
+    } catch (err) {
+      console.error(`[PlayerCastSheet] GetVolume fail: ${JSON.stringify(err)}`);
+      this.volumeSupported = false;
+      if (!this.volumeWarned) {
+        this.volumeWarned = true;
+        this.toast('设备不支持音量控制');
+      }
+    }
+  }
+
   private async castTo(device: DlnaDevice): Promise<void> {
     if (!this.mediaUrl) {
-      try {
-        this.getUIContext().getPromptAction().showToast({ message: '当前没有可投屏的视频地址' });
-      } catch (_e) {
-      }
+      this.toast('当前没有可投屏的视频地址');
       return;
     }
     this.casting = true;
     this.errorText = '';
+    this.stopPoll();
     try {
       await this.client.cast(device, this.mediaUrl, this.mediaTitle || 'EcoHub');
+      this.resetCastUi();
       this.connectedUsn = device.usn;
       this.onCasted(device);
-      try {
-        this.getUIContext().getPromptAction().showToast({ message: `已投屏到 ${device.friendlyName}` });
-      } catch (_e) {
-      }
+      this.toast(`已投屏到 ${device.friendlyName}`);
+      this.startPoll();
+      this.loadVolume(device);
     } catch (err) {
       const msg: string = err instanceof Error ? err.message : '投屏失败';
       this.errorText = msg;
-      try {
-        this.getUIContext().getPromptAction().showToast({ message: msg });
-      } catch (_e) {
-      }
+      this.toast(msg);
     } finally {
       this.casting = false;
     }
@@ -89,6 +239,7 @@ struct PlayerCastDialog {
   private async stopCast(): Promise<void> {
     const device: DlnaDevice | null = this.connectedDevice();
     this.casting = true;
+    this.stopPoll();
     try {
       if (device) {
         await this.client.stop(device);
@@ -98,12 +249,191 @@ struct PlayerCastDialog {
     } finally {
       this.casting = false;
       this.connectedUsn = '';
+      this.resetCastUi();
       this.onStopped();
-      try {
-        this.getUIContext().getPromptAction().showToast({ message: '已停止投屏' });
-      } catch (_e) {
+      this.toast('已停止投屏');
+    }
+  }
+
+  private async seekTo(sec: number): Promise<void> {
+    const device: DlnaDevice | null = this.connectedDevice();
+    if (!device) {
+      return;
+    }
+    const target: number = Math.max(0, this.castDuration > 0 ? Math.min(sec, this.castDuration) : sec);
+    try {
+      await this.client.seek(device, target);
+      this.castPosition = target;
+    } catch (err) {
+      console.error(`[PlayerCastSheet] Seek fail: ${JSON.stringify(err)}`);
+      if (!this.seekWarned) {
+        this.seekWarned = true;
+        this.toast('设备不支持进度拖动');
       }
     }
+  }
+
+  private async applyVolume(vol: number): Promise<void> {
+    const device: DlnaDevice | null = this.connectedDevice();
+    if (!device || !this.volumeSupported || this.volumeBusy) {
+      return;
+    }
+    const clamped: number = Math.max(0, Math.min(100, Math.round(vol)));
+    this.castVolume = clamped;
+    this.volumeBusy = true;
+    try {
+      await this.client.setVolume(device, clamped);
+    } catch (err) {
+      console.error(`[PlayerCastSheet] SetVolume fail: ${JSON.stringify(err)}`);
+      if (!this.volumeWarned) {
+        this.volumeWarned = true;
+        this.toast('设备不支持音量控制');
+      }
+      this.volumeSupported = false;
+    } finally {
+      this.volumeBusy = false;
+    }
+  }
+
+  private nudgeVolume(delta: number): void {
+    this.applyVolume(this.castVolume + delta);
+  }
+
+  @Builder
+  connectedControls() {
+    Column() {
+      Row() {
+        Column() {
+          Text(this.connectedName())
+            .fontSize(14)
+            .fontWeight(FontWeight.Medium)
+            .fontColor('#FFFFFF')
+            .maxLines(1)
+            .textOverflow({ overflow: TextOverflow.Ellipsis })
+          Text(this.connectedHost())
+            .fontSize(11)
+            .fontColor(AppTheme.TEXT_MUTED)
+            .margin({ top: 2 })
+        }
+        .alignItems(HorizontalAlign.Start)
+        .layoutWeight(1)
+        Text('停止投屏')
+          .fontSize(13)
+          .fontWeight(FontWeight.Bold)
+          .fontColor('#FFFFFF')
+          .padding({ left: 12, right: 12, top: 8, bottom: 8 })
+          .backgroundColor(AppTheme.DANGER)
+          .borderRadius(10)
+          .onClick(() => {
+            this.stopCast();
+          })
+      }
+      .width('100%')
+
+      // Progress + scrubber
+      Column() {
+        Text(this.castTimeText())
+          .fontSize(12)
+          .fontColor(AppTheme.TEXT_SECONDARY)
+          .width('100%')
+          .margin({ bottom: 4 })
+        Slider({
+          value: this.castPosition,
+          min: 0,
+          max: this.castDuration > 0 ? this.castDuration : 1,
+          step: 1,
+          style: SliderStyle.OutSet
+        })
+          .width('100%')
+          .height(20)
+          .trackThickness(2)
+          .blockSize({ width: 12, height: 12 })
+          .blockColor('#FFFFFF')
+          .trackColor('rgba(255,255,255,0.28)')
+          .selectedColor(AppTheme.ACCENT)
+          .enabled(this.castDuration > 0 && !this.casting)
+          .onChange((value: number, mode: SliderChangeMode) => {
+            this.castPosition = value;
+            if (mode === SliderChangeMode.Begin || mode === SliderChangeMode.Moving) {
+              this.scrubbing = true;
+            } else if (mode === SliderChangeMode.End) {
+              this.scrubbing = false;
+              this.seekTo(value);
+            } else if (mode === SliderChangeMode.Click) {
+              this.scrubbing = false;
+              this.seekTo(value);
+            }
+          })
+      }
+      .width('100%')
+      .margin({ top: 12 })
+
+      // Volume
+      if (this.volumeSupported) {
+        Row() {
+          Text('音量')
+            .fontSize(12)
+            .fontColor(AppTheme.TEXT_SECONDARY)
+            .width(36)
+          Text('−')
+            .fontSize(18)
+            .fontWeight(FontWeight.Bold)
+            .fontColor('#FFFFFF')
+            .width(32)
+            .height(32)
+            .textAlign(TextAlign.Center)
+            .backgroundColor('rgba(255,255,255,0.08)')
+            .borderRadius(8)
+            .onClick(() => this.nudgeVolume(-5))
+          Slider({
+            value: this.castVolume,
+            min: 0,
+            max: 100,
+            step: 1,
+            style: SliderStyle.OutSet
+          })
+            .layoutWeight(1)
+            .height(20)
+            .trackThickness(2)
+            .blockSize({ width: 12, height: 12 })
+            .blockColor('#FFFFFF')
+            .trackColor('rgba(255,255,255,0.28)')
+            .selectedColor(AppTheme.ACCENT)
+            .margin({ left: 6, right: 6 })
+            .enabled(!this.casting && !this.volumeBusy)
+            .onChange((value: number, mode: SliderChangeMode) => {
+              this.castVolume = value;
+              if (mode === SliderChangeMode.End || mode === SliderChangeMode.Click) {
+                this.applyVolume(value);
+              }
+            })
+          Text('+')
+            .fontSize(18)
+            .fontWeight(FontWeight.Bold)
+            .fontColor('#FFFFFF')
+            .width(32)
+            .height(32)
+            .textAlign(TextAlign.Center)
+            .backgroundColor('rgba(255,255,255,0.08)')
+            .borderRadius(8)
+            .onClick(() => this.nudgeVolume(5))
+          Text(`${Math.round(this.castVolume)}`)
+            .fontSize(12)
+            .fontColor(AppTheme.TEXT_MUTED)
+            .width(28)
+            .textAlign(TextAlign.End)
+            .margin({ left: 4 })
+        }
+        .width('100%')
+        .margin({ top: 10 })
+        .alignItems(VerticalAlign.Center)
+      }
+    }
+    .width('100%')
+    .padding(12)
+    .margin({ bottom: 10 })
+    .backgroundColor(AppTheme.ACCENT_SOFT)
+    .borderRadius(12)
   }
 
   build() {
@@ -134,37 +464,7 @@ struct PlayerCastDialog {
         .width('100%')
 
       if (this.connectedUsn) {
-        Row() {
-          Column() {
-            Text(this.connectedName())
-              .fontSize(14)
-              .fontWeight(FontWeight.Medium)
-              .fontColor('#FFFFFF')
-              .maxLines(1)
-              .textOverflow({ overflow: TextOverflow.Ellipsis })
-            Text(this.connectedHost())
-              .fontSize(11)
-              .fontColor(AppTheme.TEXT_MUTED)
-              .margin({ top: 2 })
-          }
-          .alignItems(HorizontalAlign.Start)
-          .layoutWeight(1)
-          Text('停止投屏')
-            .fontSize(13)
-            .fontWeight(FontWeight.Bold)
-            .fontColor('#FFFFFF')
-            .padding({ left: 12, right: 12, top: 8, bottom: 8 })
-            .backgroundColor(AppTheme.DANGER)
-            .borderRadius(10)
-            .onClick(() => {
-              this.stopCast();
-            })
-        }
-        .width('100%')
-        .padding(12)
-        .margin({ bottom: 10 })
-        .backgroundColor(AppTheme.ACCENT_SOFT)
-        .borderRadius(12)
+        this.connectedControls()
       }
 
       if (this.scanState === DlnaScanState.SCANNING && this.devices.length === 0) {
@@ -361,7 +661,6 @@ export struct PlayerCastSheet {
     });
     this.devices = merged;
   }
-
 
   build() {
     Column()

--- a/entry/src/main/ets/components/PlayerCastSheet.ets
+++ b/entry/src/main/ets/components/PlayerCastSheet.ets
@@ -1,0 +1,361 @@
+import { AppTheme } from '../common/constants/AppTheme';
+import { DlnaClient } from '../common/utils/DlnaClient';
+import { DlnaDevice, DlnaScanState } from '../common/utils/DlnaTypes';
+
+@CustomDialog
+struct PlayerCastDialog {
+  controller?: CustomDialogController;
+  @Link devices: DlnaDevice[];
+  @Link scanState: number;
+  @Link errorText: string;
+  @Link connectedUsn: string;
+  @Link casting: boolean;
+  mediaUrl: string = '';
+  mediaTitle: string = '';
+  onCasted: (device: DlnaDevice) => void = (_d: DlnaDevice) => {};
+  onStopped: () => void = () => {};
+  onRescan: () => void = () => {};
+  private client: DlnaClient = new DlnaClient();
+
+  private statusText(): string {
+    if (this.casting) {
+      return '正在投屏…';
+    }
+    if (this.scanState === DlnaScanState.SCANNING) {
+      return '正在搜索同一 Wi‑Fi 下的电视/盒子…';
+    }
+    if (this.scanState === DlnaScanState.ERROR) {
+      return this.errorText || '搜索失败，请确认已连接 Wi‑Fi 后重试';
+    }
+    if (this.devices.length === 0) {
+      return '未发现可投屏设备，请确认电视已开启投屏且与手机同一局域网';
+    }
+    return `发现 ${this.devices.length} 台设备，点选即可投屏`;
+  }
+
+  private connectedDevice(): DlnaDevice | null {
+    if (!this.connectedUsn) {
+      return null;
+    }
+    for (let i = 0; i < this.devices.length; i++) {
+      if (this.devices[i].usn === this.connectedUsn) {
+        return this.devices[i];
+      }
+    }
+    return null;
+  }
+
+  private async castTo(device: DlnaDevice): Promise<void> {
+    if (!this.mediaUrl) {
+      try {
+        this.getUIContext().getPromptAction().showToast({ message: '当前没有可投屏的视频地址' });
+      } catch (_e) {
+      }
+      return;
+    }
+    this.casting = true;
+    this.errorText = '';
+    try {
+      await this.client.cast(device, this.mediaUrl, this.mediaTitle || 'EcoHub');
+      this.connectedUsn = device.usn;
+      this.onCasted(device);
+      try {
+        this.getUIContext().getPromptAction().showToast({ message: `已投屏到 ${device.friendlyName}` });
+      } catch (_e) {
+      }
+    } catch (err) {
+      const msg: string = err instanceof Error ? err.message : '投屏失败';
+      this.errorText = msg;
+      try {
+        this.getUIContext().getPromptAction().showToast({ message: msg });
+      } catch (_e) {
+      }
+    } finally {
+      this.casting = false;
+    }
+  }
+
+  private async stopCast(): Promise<void> {
+    const device: DlnaDevice | null = this.connectedDevice();
+    this.casting = true;
+    try {
+      if (device) {
+        await this.client.stop(device);
+      }
+    } catch (err) {
+      console.error(`[PlayerCastSheet] stop failed: ${JSON.stringify(err)}`);
+    } finally {
+      this.casting = false;
+      this.connectedUsn = '';
+      this.onStopped();
+      try {
+        this.getUIContext().getPromptAction().showToast({ message: '已停止投屏' });
+      } catch (_e) {
+      }
+    }
+  }
+
+  build() {
+    Column() {
+      Row() {
+        Text('投屏到电视')
+          .fontSize(16)
+          .fontWeight(FontWeight.Bold)
+          .fontColor('#FFFFFF')
+        Blank()
+        Text('刷新')
+          .fontSize(13)
+          .fontWeight(FontWeight.Medium)
+          .fontColor(this.scanState === DlnaScanState.SCANNING ? AppTheme.TEXT_MUTED : AppTheme.ACCENT)
+          .padding({ left: 8, right: 4, top: 6, bottom: 6 })
+          .onClick(() => {
+            if (this.scanState !== DlnaScanState.SCANNING && !this.casting) {
+              this.onRescan();
+            }
+          })
+      }
+      .width('100%')
+
+      Text(this.statusText())
+        .fontSize(12)
+        .fontColor('rgba(255,255,255,0.55)')
+        .margin({ top: 6, bottom: 12 })
+        .width('100%')
+
+      if (this.connectedUsn) {
+        Row() {
+          Column() {
+            Text(this.connectedName())
+              .fontSize(14)
+              .fontWeight(FontWeight.Medium)
+              .fontColor('#FFFFFF')
+              .maxLines(1)
+              .textOverflow({ overflow: TextOverflow.Ellipsis })
+            Text(this.connectedHost())
+              .fontSize(11)
+              .fontColor(AppTheme.TEXT_MUTED)
+              .margin({ top: 2 })
+          }
+          .alignItems(HorizontalAlign.Start)
+          .layoutWeight(1)
+          Text('停止投屏')
+            .fontSize(13)
+            .fontWeight(FontWeight.Bold)
+            .fontColor('#FFFFFF')
+            .padding({ left: 12, right: 12, top: 8, bottom: 8 })
+            .backgroundColor(AppTheme.DANGER)
+            .borderRadius(10)
+            .onClick(() => {
+              this.stopCast();
+            })
+        }
+        .width('100%')
+        .padding(12)
+        .margin({ bottom: 10 })
+        .backgroundColor(AppTheme.ACCENT_SOFT)
+        .borderRadius(12)
+      }
+
+      if (this.scanState === DlnaScanState.SCANNING && this.devices.length === 0) {
+        Row() {
+          LoadingProgress()
+            .width(28)
+            .height(28)
+            .color(AppTheme.ACCENT)
+          Text('扫描中…')
+            .fontSize(13)
+            .fontColor(AppTheme.TEXT_SECONDARY)
+            .margin({ left: 10 })
+        }
+        .width('100%')
+        .height(72)
+        .justifyContent(FlexAlign.Center)
+      } else if (this.devices.length === 0) {
+        Text(this.scanState === DlnaScanState.ERROR ? '点击右上角刷新重试' : '暂无设备')
+          .fontSize(13)
+          .fontColor(AppTheme.TEXT_MUTED)
+          .width('100%')
+          .height(72)
+          .textAlign(TextAlign.Center)
+      } else {
+        List({ space: 8 }) {
+          ForEach(this.devices, (device: DlnaDevice) => {
+            ListItem() {
+              Row() {
+                Column() {
+                  Text(device.friendlyName)
+                    .fontSize(14)
+                    .fontWeight(FontWeight.Medium)
+                    .fontColor('#FFFFFF')
+                    .maxLines(1)
+                    .textOverflow({ overflow: TextOverflow.Ellipsis })
+                  Text(device.manufacturer ? `${device.manufacturer} · ${device.host}` : device.host)
+                    .fontSize(11)
+                    .fontColor(AppTheme.TEXT_MUTED)
+                    .margin({ top: 2 })
+                    .maxLines(1)
+                    .textOverflow({ overflow: TextOverflow.Ellipsis })
+                }
+                .alignItems(HorizontalAlign.Start)
+                .layoutWeight(1)
+                if (this.connectedUsn === device.usn) {
+                  Text('已连接')
+                    .fontSize(12)
+                    .fontColor(AppTheme.ACCENT)
+                } else {
+                  Text('投屏')
+                    .fontSize(12)
+                    .fontWeight(FontWeight.Bold)
+                    .fontColor('#FFFFFF')
+                    .padding({ left: 10, right: 10, top: 6, bottom: 6 })
+                    .backgroundColor(AppTheme.ACCENT)
+                    .borderRadius(8)
+                    .opacity(this.casting ? 0.5 : 1)
+                }
+              }
+              .width('100%')
+              .padding(12)
+              .backgroundColor(this.connectedUsn === device.usn ? AppTheme.ACCENT_SOFT : 'rgba(255,255,255,0.06)')
+              .borderRadius(12)
+              .onClick(() => {
+                if (!this.casting && this.connectedUsn !== device.usn) {
+                  this.castTo(device);
+                }
+              })
+            }
+          }, (device: DlnaDevice) => device.usn)
+        }
+        .width('100%')
+        .constraintSize({ maxHeight: 280 })
+        .scrollBar(BarState.Off)
+      }
+    }
+    .width('100%')
+    .padding({ left: 16, right: 16, top: 16, bottom: 28 })
+    .backgroundColor('#191B20')
+    .borderRadius({ topLeft: 20, topRight: 20 })
+  }
+}
+
+@Component
+export struct PlayerCastSheet {
+  @Prop @Watch('onOpenChange') openSeq: number = 0;
+  @Prop mediaUrl: string = '';
+  @Prop mediaTitle: string = '';
+  onCasted: (device: DlnaDevice) => void = (_device: DlnaDevice) => {};
+  onStopped: () => void = () => {};
+  onClosed: () => void = () => {};
+
+  @State private devices: DlnaDevice[] = [];
+  @State private scanState: number = DlnaScanState.IDLE;
+  @State private errorText: string = '';
+  @State private connectedUsn: string = '';
+  @State private casting: boolean = false;
+
+  private dialog: CustomDialogController | null = null;
+  private client: DlnaClient = new DlnaClient();
+  private connectedDeviceCache: DlnaDevice | null = null;
+
+  aboutToDisappear(): void {
+    this.client.cancelDiscover();
+    this.close();
+  }
+
+  onOpenChange(): void {
+    this.close();
+    if (this.openSeq <= 0) {
+      return;
+    }
+    this.open();
+    this.startScan();
+  }
+
+  private open(): void {
+    this.dialog = new CustomDialogController({
+      builder: PlayerCastDialog({
+        devices: $devices,
+        scanState: $scanState,
+        errorText: $errorText,
+        connectedUsn: $connectedUsn,
+        casting: $casting,
+        mediaUrl: this.mediaUrl,
+        mediaTitle: this.mediaTitle,
+        onCasted: (device: DlnaDevice) => {
+          this.connectedDeviceCache = device;
+          this.onCasted(device);
+        },
+        onStopped: () => {
+          this.connectedDeviceCache = null;
+          this.onStopped();
+        },
+        onRescan: () => this.startScan()
+      }),
+      autoCancel: true,
+      alignment: DialogAlignment.Bottom,
+      customStyle: true,
+      backgroundColor: Color.Transparent,
+      maskColor: 'rgba(0,0,0,0.52)',
+      cancel: () => {
+        this.dialog = null;
+        this.client.cancelDiscover();
+        this.onClosed();
+      }
+    });
+    this.dialog.open();
+  }
+
+  private close(): void {
+    if (this.dialog) {
+      this.dialog.close();
+      this.dialog = null;
+    }
+  }
+
+  private startScan(): void {
+    this.client.cancelDiscover();
+    this.scanState = DlnaScanState.SCANNING;
+    this.errorText = '';
+    // Keep connected device visible while rescanning.
+    const keep: DlnaDevice[] = [];
+    if (this.connectedDeviceCache && this.connectedUsn) {
+      keep.push(this.connectedDeviceCache);
+    }
+    this.devices = keep;
+    this.client.discover((list: DlnaDevice[]) => {
+      this.mergeDevices(list);
+    }).then((list: DlnaDevice[]) => {
+      this.mergeDevices(list);
+      this.scanState = DlnaScanState.DONE;
+    }).catch((err: Object) => {
+      const msg: string = err instanceof Error ? err.message : '搜索失败';
+      this.errorText = msg;
+      this.scanState = DlnaScanState.ERROR;
+    });
+  }
+
+  private mergeDevices(list: DlnaDevice[]): void {
+    const map: Map<string, DlnaDevice> = new Map();
+    if (this.connectedDeviceCache && this.connectedUsn) {
+      map.set(this.connectedUsn, this.connectedDeviceCache);
+    }
+    for (let i = 0; i < list.length; i++) {
+      const d: DlnaDevice = list[i];
+      if (d.controlURL) {
+        map.set(d.usn, d);
+      }
+    }
+    const merged: DlnaDevice[] = [];
+    map.forEach((d: DlnaDevice) => {
+      merged.push(d);
+    });
+    this.devices = merged;
+  }
+
+
+  build() {
+    Column()
+      .width(0)
+      .height(0)
+      .hitTestBehavior(HitTestMode.None)
+  }
+}

--- a/entry/src/main/ets/components/PlayerControl.ets
+++ b/entry/src/main/ets/components/PlayerControl.ets
@@ -9,6 +9,7 @@ export struct PlayerIconBtn {
   @Prop circle: boolean = false;
   @Prop prominent: boolean = false;
   @Prop canTap: boolean = true;
+  @Prop iconColor: string = '#FFFFFF';
   onTap?: () => void;
   private lastTapAt: number = 0;
 
@@ -37,7 +38,7 @@ export struct PlayerIconBtn {
     Column() {
       SymbolGlyph(this.src)
         .fontSize(this.iconSize)
-        .fontColor(['#FFFFFF'])
+        .fontColor([this.iconColor])
         .fontWeight(FontWeight.Medium)
         .hitTestBehavior(HitTestMode.None)
     }

--- a/entry/src/main/ets/components/PlayerGesture.ets
+++ b/entry/src/main/ets/components/PlayerGesture.ets
@@ -1,5 +1,6 @@
 @Component
 export struct PlayerGestureLayer {
+  @Prop ignoreHit: boolean = false;
   onPlay?: () => void;
   onToggleHud?: () => void;
   onLongPress?: () => void;
@@ -14,7 +15,7 @@ export struct PlayerGestureLayer {
       .width('100%')
       .height('100%')
       .backgroundColor(Color.Transparent)
-      .hitTestBehavior(HitTestMode.Default)
+      .hitTestBehavior(this.ignoreHit ? HitTestMode.None : HitTestMode.Default)
       .gesture(
         GestureGroup(GestureMode.Exclusive,
           TapGesture({ count: 2 })

--- a/entry/src/main/ets/components/PlayerPlaybackState.ets
+++ b/entry/src/main/ets/components/PlayerPlaybackState.ets
@@ -31,6 +31,8 @@ export class PlayerPlaybackState {
   public dragging: boolean = false;
   public videoWidth: number = 0;
   public videoHeight: number = 0;
+  /** Consume-once resume after stopping cast; -1 = unset. */
+  public pendingResumeSec: number = -1;
 
   public live(): boolean {
     return this.playerOn && this.bootGen === this.mountGen;
@@ -45,6 +47,11 @@ export class PlayerPlaybackState {
   }
 
   public resumeTime(initialTime: number): number {
+    if (this.pendingResumeSec >= 0) {
+      const t: number = this.pendingResumeSec;
+      this.pendingResumeSec = -1;
+      return t;
+    }
     return this.currentTime >= PlayerPlaybackState.MIN_RESUME_THRESHOLD_SEC ? this.currentTime : initialTime;
   }
 
@@ -71,6 +78,7 @@ export class PlayerPlaybackState {
     this.lastToggleAt = 0;
     this.videoWidth = 0;
     this.videoHeight = 0;
+    this.pendingResumeSec = -1;
   }
 
   public emitProgress(cb?: ProgressCallback, force: boolean = false): void {
@@ -93,6 +101,9 @@ export class PlayerPlaybackState {
     if (this.seeking || this.seekTarget >= 0) {
       return false;
     }
+    if (this.pendingResumeSec >= 0 && this.opening) {
+      return false;
+    }
     this.currentTime = time;
     return true;
   }
@@ -109,6 +120,7 @@ export class PlayerPlaybackState {
     this.seekTarget = -1;
     this.seekAt = 0;
     this.seekSeq = 0;
+    this.pendingResumeSec = -1;
   }
 
   public failOpen(url: string, detail?: string): void {

--- a/entry/src/main/ets/components/PlayerSkin.ets
+++ b/entry/src/main/ets/components/PlayerSkin.ets
@@ -34,6 +34,7 @@ export struct PlayerSkin {
   @Prop edgeHud: boolean = false;
   @Prop ready: boolean = false;
   @Prop stalled: boolean = false;
+  @Prop castDeviceName: string = '';
   onBack?: () => void;
   onPlay?: () => void;
   onFull?: () => void;
@@ -57,12 +58,16 @@ export struct PlayerSkin {
   onPanEnd?: () => void;
   onPanCancel?: () => void;
   onCast?: () => void;
+  onStopCast?: () => void;
 
   private continuing(): boolean {
     return this.playRequested && !this.completed && !this.errorText;
   }
 
   private loading(): boolean {
+    if (this.castDeviceName) {
+      return false;
+    }
     if (this.errorText) {
       return false;
     }
@@ -86,10 +91,16 @@ export struct PlayerSkin {
   }
 
   private showCenterPlay(): boolean {
+    if (this.castDeviceName) {
+      return false;
+    }
     return this.showHud && this.ready && !this.loading() && !this.errorText && !this.continuing();
   }
 
   private showBottom(): boolean {
+    if (this.castDeviceName) {
+      return false;
+    }
     return this.showHud && this.ready && !this.errorText;
   }
 
@@ -110,6 +121,9 @@ export struct PlayerSkin {
   }
 
   private handleCast(): void {
+    if (this.isFull) {
+      return;
+    }
     if (this.onCast) {
       this.onCast();
       return;
@@ -176,12 +190,6 @@ export struct PlayerSkin {
           .layoutWeight(1)
           .margin({ left: 4, right: 8 })
         this.skipBtns()
-        PlayerIconBtn({
-          src: $r('sys.symbol.wireless_projection'),
-          iconSize: 20,
-          boxSize: 40,
-          onTap: () => this.handleCast()
-        })
       }
       .width('100%')
       .padding({
@@ -206,6 +214,30 @@ export struct PlayerSkin {
       boxSize: 44,
       onTap: this.onPlay
     })
+  }
+
+  @Builder
+  castEntry() {
+    if (this.castDeviceName) {
+      PlayerIconBtn({
+        src: $r('sys.symbol.power'),
+        iconSize: 18,
+        boxSize: 40,
+        iconColor: AppTheme.DANGER,
+        onTap: () => {
+          if (this.onStopCast) {
+            this.onStopCast();
+          }
+        }
+      })
+    } else {
+      PlayerIconBtn({
+        src: $r('sys.symbol.wireless_projection'),
+        iconSize: 20,
+        boxSize: 40,
+        onTap: () => this.handleCast()
+      })
+    }
   }
 
   @Builder
@@ -248,13 +280,15 @@ export struct PlayerSkin {
               boxSize: 44,
               onTap: this.onMute
             })
-            PlayerIconBtn({
-              src: this.isFull ? $r('sys.symbol.arrow_down_right_and_arrow_up_left') :
-                $r('sys.symbol.arrow_up_left_and_arrow_down_right'),
-              iconSize: 18,
-              boxSize: 44,
-              onTap: this.onFull
-            })
+            if (!this.castDeviceName) {
+              PlayerIconBtn({
+                src: this.isFull ? $r('sys.symbol.arrow_down_right_and_arrow_up_left') :
+                  $r('sys.symbol.arrow_up_left_and_arrow_down_right'),
+                iconSize: 18,
+                boxSize: 44,
+                onTap: this.onFull
+              })
+            }
           }
           .width('100%')
           .height(44)
@@ -284,12 +318,14 @@ export struct PlayerSkin {
             .fontColor('rgba(255,255,255,0.88)')
             .maxLines(1)
           PlayerChip({ label: this.speedLabel, canTap: this.ready, onTap: this.onSpeed })
-          PlayerIconBtn({
-            src: $r('sys.symbol.arrow_up_left_and_arrow_down_right'),
-            iconSize: 18,
-            boxSize: 44,
-            onTap: this.onFull
-          })
+          if (!this.castDeviceName) {
+            PlayerIconBtn({
+              src: $r('sys.symbol.arrow_up_left_and_arrow_down_right'),
+              iconSize: 18,
+              boxSize: 44,
+              onTap: this.onFull
+            })
+          }
         }
         .width('100%')
         .height(44)
@@ -359,6 +395,7 @@ export struct PlayerSkin {
   build() {
     Stack({ alignContent: Alignment.TopStart }) {
       PlayerGestureLayer({
+        ignoreHit: !!this.castDeviceName,
         onPlay: this.onPlay,
         onToggleHud: this.onToggleHud,
         onLongPress: this.onLongPress,
@@ -379,7 +416,7 @@ export struct PlayerSkin {
           .hitTestBehavior(HitTestMode.None)
       }
 
-      if (this.errorText) {
+      if (this.errorText && !this.castDeviceName) {
         PlayerErrorPad({
           onRetry: () => {
             if (this.onRetry) {
@@ -421,14 +458,11 @@ export struct PlayerSkin {
             PlayerBackBtn({ onTap: this.onBack })
           }
           Blank().hitTestBehavior(HitTestMode.None)
-          PlayerIconBtn({
-            src: $r('sys.symbol.wireless_projection'),
-            iconSize: 20,
-            boxSize: 40,
-            onTap: () => this.handleCast()
-          })
+          this.castEntry()
         }
         .width('100%')
+        .justifyContent(FlexAlign.SpaceBetween)
+        .alignItems(VerticalAlign.Center)
         .padding({
           left: this.edge(4, this.leftInset),
           right: this.edge(4, this.rightInset),
@@ -441,5 +475,6 @@ export struct PlayerSkin {
     .width('100%')
     .height('100%')
     .clip(true)
+    .hitTestBehavior(HitTestMode.Transparent)
   }
 }

--- a/entry/src/main/ets/components/PlayerSkin.ets
+++ b/entry/src/main/ets/components/PlayerSkin.ets
@@ -56,6 +56,7 @@ export struct PlayerSkin {
   onPanMove?: (event: GestureEvent) => void;
   onPanEnd?: () => void;
   onPanCancel?: () => void;
+  onCast?: () => void;
 
   private continuing(): boolean {
     return this.playRequested && !this.completed && !this.errorText;
@@ -109,8 +110,12 @@ export struct PlayerSkin {
   }
 
   private handleCast(): void {
+    if (this.onCast) {
+      this.onCast();
+      return;
+    }
     try {
-      this.getUIContext().getPromptAction().showToast({ message: '正在开发中' });
+      this.getUIContext().getPromptAction().showToast({ message: '投屏不可用' });
     } catch (_e) {}
   }
 
@@ -171,6 +176,12 @@ export struct PlayerSkin {
           .layoutWeight(1)
           .margin({ left: 4, right: 8 })
         this.skipBtns()
+        PlayerIconBtn({
+          src: $r('sys.symbol.wireless_projection'),
+          iconSize: 20,
+          boxSize: 40,
+          onTap: () => this.handleCast()
+        })
       }
       .width('100%')
       .padding({

--- a/entry/src/main/ets/components/PlayerSkinView.ets
+++ b/entry/src/main/ets/components/PlayerSkinView.ets
@@ -24,6 +24,7 @@ export interface PlayerSkinEvents {
   onPanEnd: () => void;
   onPanCancel: () => void;
   onCast: () => void;
+  onStopCast: () => void;
 }
 
 @Component
@@ -55,6 +56,7 @@ export struct PlayerSkinView {
   @Prop bottomInset: number = 0;
   @Prop edgeHud: boolean = false;
   @Prop ready: boolean = false;
+  @Prop castDeviceName: string = '';
 
   events?: PlayerSkinEvents;
 
@@ -87,6 +89,7 @@ export struct PlayerSkinView {
       bottomInset: this.bottomInset,
       edgeHud: this.edgeHud,
       ready: this.ready,
+      castDeviceName: this.castDeviceName,
       onBack: () => { if (this.events) this.events.onBack(); },
       onPlay: () => { if (this.events) this.events.onPlay(); },
       onFull: () => { if (this.events) this.events.onFull(); },
@@ -109,7 +112,8 @@ export struct PlayerSkinView {
       onPanMove: (e: GestureEvent) => { if (this.events) this.events.onPanMove(e); },
       onPanEnd: () => { if (this.events) this.events.onPanEnd(); },
       onPanCancel: () => { if (this.events) this.events.onPanCancel(); },
-      onCast: () => { if (this.events) this.events.onCast(); }
+      onCast: () => { if (this.events) this.events.onCast(); },
+      onStopCast: () => { if (this.events) this.events.onStopCast(); }
     })
       .width('100%')
       .height('100%')

--- a/entry/src/main/ets/components/PlayerSkinView.ets
+++ b/entry/src/main/ets/components/PlayerSkinView.ets
@@ -23,6 +23,7 @@ export interface PlayerSkinEvents {
   onPanMove: (event: GestureEvent) => void;
   onPanEnd: () => void;
   onPanCancel: () => void;
+  onCast: () => void;
 }
 
 @Component
@@ -107,7 +108,8 @@ export struct PlayerSkinView {
       onPanStart: (e: GestureEvent) => { if (this.events) this.events.onPanStart(e); },
       onPanMove: (e: GestureEvent) => { if (this.events) this.events.onPanMove(e); },
       onPanEnd: () => { if (this.events) this.events.onPanEnd(); },
-      onPanCancel: () => { if (this.events) this.events.onPanCancel(); }
+      onPanCancel: () => { if (this.events) this.events.onPanCancel(); },
+      onCast: () => { if (this.events) this.events.onCast(); }
     })
       .width('100%')
       .height('100%')

--- a/entry/src/main/ets/components/PlayerVideoObserver.ets
+++ b/entry/src/main/ets/components/PlayerVideoObserver.ets
@@ -38,7 +38,7 @@ export class PlayerVideoObserver {
     this.host.state.opening = false;
     this.host.state.errorText = '';
     const resumeAt = this.host.state.resumeTime(this.host.initialTime);
-    if (resumeAt >= 2) {
+    if (resumeAt >= PlayerPlaybackState.MIN_RESUME_THRESHOLD_SEC) {
       this.host.state.seek(resumeAt, this.host.playerAv);
       this.host.armSeekWatch();
     }

--- a/entry/src/main/ets/components/VideoPlayer.ets
+++ b/entry/src/main/ets/components/VideoPlayer.ets
@@ -13,6 +13,9 @@ import { PlayerPlaybackState } from './PlayerPlaybackState';
 import { PlayerSkinEvents, PlayerSkinView } from './PlayerSkinView';
 import { PlayerObserverHost, PlayerVideoObserver } from './PlayerVideoObserver';
 import { PlayerSpeedSheet } from './PlayerSpeedSheet';
+import { PlayerCastSheet } from './PlayerCastSheet';
+import { DlnaClient } from '../common/utils/DlnaClient';
+import { DlnaDevice } from '../common/utils/DlnaTypes';
 import { PlayerScale, PlayerScaleMode } from '../common/utils/PlayerScale';
 import { PlayerScaleController } from './PlayerScaleController';
 import { PlayerAv } from '../common/utils/PlayerAv';
@@ -71,6 +74,8 @@ export struct VideoPlayer {
   @State private playSrc: string = '';
   @State private playerOn: boolean = false;
   @State private speedOpenSeq: number = 0;
+  @State private castOpenSeq: number = 0;
+  @State private castDeviceName: string = '';
 
   private playerAv: PlayerAv = new PlayerAv();
   private watcher: PlayerStallWatcher = new PlayerStallWatcher();
@@ -84,6 +89,8 @@ export struct VideoPlayer {
   private playerW: number = 1;
   private playerH: number = 1;
   private volumeSub: (() => void) | null = null;
+  private castClient: DlnaClient = new DlnaClient();
+  private castDevice: DlnaDevice | null = null;
 
   aboutToAppear() {
     this.observer = new PlayerVideoObserver(this.observerHost());
@@ -138,6 +145,8 @@ export struct VideoPlayer {
       this.volumeSub();
       this.volumeSub = null;
     }
+    this.closeCastDialog();
+    this.stopCastSession();
     this.playerAv.release();
     this.watcher.clearAll();
     this.closeSpeedDialog();
@@ -210,6 +219,7 @@ export struct VideoPlayer {
       this.state.stalled = false;
       this.watcher.clearHide();
       this.closeSpeedDialog();
+      this.closeCastDialog();
       this.syncFromState();
       if (this.state.currentTime > 0) this.state.emitProgress(this.onProgress, true);
       if (this.state.isPlaying) this.playerAv.pause();
@@ -334,6 +344,34 @@ export struct VideoPlayer {
 
   private openSpeedDialog(): void { this.speedCtrl.setShowing(true); this.speedOpenSeq += 1; }
   private closeSpeedDialog(): void { this.speedCtrl.setShowing(false); this.speedOpenSeq = 0; }
+  private openCastDialog(): void {
+    this.closeSpeedDialog();
+    this.castOpenSeq += 1;
+    this.pulseHud();
+  }
+  private closeCastDialog(): void { this.castOpenSeq = 0; }
+  private pauseForCast(): void {
+    if (this.state.playRequested || this.state.isPlaying) {
+      this.state.playRequested = false;
+      this.state.isPlaying = false;
+      this.playerAv.pause();
+      this.syncFromState();
+      this.syncKeepScreen();
+      this.showHud = true;
+      this.watcher.clearHide();
+    }
+  }
+  private stopCastSession(): void {
+    const device: DlnaDevice | null = this.castDevice;
+    this.castDevice = null;
+    this.castDeviceName = '';
+    if (!device) {
+      return;
+    }
+    this.castClient.stop(device).catch((err: Object) => {
+      console.error(`[VideoPlayer] cast stop failed: ${JSON.stringify(err)}`);
+    });
+  }
   private cycleScaleMode(): void {
     const next = this.scaleCtrl.cycle();
     this.scaleMode = next;
@@ -420,7 +458,8 @@ export struct VideoPlayer {
         }
       },
       onPanStart: (e) => this.gestures.start(e, this.state.canPlay(), this.longPressing, this.currentTime, this.playerW, this.ctx()),
-      onPanMove: (e) => this.panMove(e), onPanEnd: () => this.finishPanSeek(), onPanCancel: () => this.finishPanSeek()
+      onPanMove: (e) => this.panMove(e), onPanEnd: () => this.finishPanSeek(), onPanCancel: () => this.finishPanSeek(),
+      onCast: () => this.openCastDialog()
     };
   }
 
@@ -458,6 +497,23 @@ export struct VideoPlayer {
         onClosed: () => this.speedCtrl.setShowing(false)
       })
 
+      PlayerCastSheet({
+        openSeq: this.castOpenSeq,
+        mediaUrl: this.videoUrl,
+        mediaTitle: this.title,
+        onCasted: (device: DlnaDevice) => {
+          this.castDevice = device;
+          this.castDeviceName = device.friendlyName;
+          this.pauseForCast();
+          this.pulseHud();
+        },
+        onStopped: () => {
+          this.castDevice = null;
+          this.castDeviceName = '';
+          this.pulseHud();
+        },
+        onClosed: () => this.closeCastDialog()
+      })
 
       PlayerSkinView({
         isFull: this.fullNow(), showHud: this.showHud, showBack: this.showBack, title: this.title,

--- a/entry/src/main/ets/components/VideoPlayer.ets
+++ b/entry/src/main/ets/components/VideoPlayer.ets
@@ -96,6 +96,9 @@ export struct VideoPlayer {
   private castSession: CastSession = new CastSession();
 
   aboutToAppear() {
+    this.castSession.onRemoteDisconnected = () => {
+      this.handleRemoteCastDisconnect();
+    };
     this.observer = new PlayerVideoObserver(this.observerHost());
     this.setupPlayerAvListener();
     this.nonce = 1;
@@ -417,6 +420,16 @@ export struct VideoPlayer {
     this.castConnectedUsn = '';
     this.castSession.clearLocal();
   }
+  /** TV stopped / powered off / network drop — local clear only, no Stop SOAP. */
+  private handleRemoteCastDisconnect(): void {
+    this.clearCastLocal();
+    this.closeCastDialog();
+    try {
+      this.getUIContext().getPromptAction().showToast({ message: '电视已停止投屏' });
+    } catch (_e) {
+    }
+    this.pulseHud();
+  }
   private stopCastSession(): void {
     const device: DlnaDevice | null = this.castDevice || this.castSession.device;
     this.clearCastLocal();
@@ -562,6 +575,7 @@ export struct VideoPlayer {
         seedDuration: this.castSession.durationSec,
         seedVolume: this.castSession.volume,
         seedVolumeSupported: this.castSession.volumeSupported,
+        castSession: this.castSession,
         onCasted: (device: DlnaDevice) => {
           this.bindCastDevice(device);
           this.pauseForCast();

--- a/entry/src/main/ets/components/VideoPlayer.ets
+++ b/entry/src/main/ets/components/VideoPlayer.ets
@@ -16,6 +16,7 @@ import { PlayerSpeedSheet } from './PlayerSpeedSheet';
 import { PlayerCastSheet } from './PlayerCastSheet';
 import { DlnaClient } from '../common/utils/DlnaClient';
 import { DlnaDevice } from '../common/utils/DlnaTypes';
+import { CastSession } from '../common/utils/CastSession';
 import { PlayerScale, PlayerScaleMode } from '../common/utils/PlayerScale';
 import { PlayerScaleController } from './PlayerScaleController';
 import { PlayerAv } from '../common/utils/PlayerAv';
@@ -76,6 +77,8 @@ export struct VideoPlayer {
   @State private speedOpenSeq: number = 0;
   @State private castOpenSeq: number = 0;
   @State private castDeviceName: string = '';
+  @State private castConnectedUsn: string = '';
+  @State private castDevice: DlnaDevice | null = null;
 
   private playerAv: PlayerAv = new PlayerAv();
   private watcher: PlayerStallWatcher = new PlayerStallWatcher();
@@ -90,7 +93,7 @@ export struct VideoPlayer {
   private playerH: number = 1;
   private volumeSub: (() => void) | null = null;
   private castClient: DlnaClient = new DlnaClient();
-  private castDevice: DlnaDevice | null = null;
+  private castSession: CastSession = new CastSession();
 
   aboutToAppear() {
     this.observer = new PlayerVideoObserver(this.observerHost());
@@ -146,6 +149,8 @@ export struct VideoPlayer {
       this.volumeSub = null;
     }
     this.closeCastDialog();
+    // True leave of PlayPage (navigate away). Screen-off uses onPageHide → pageActive=false
+    // and must NOT Stop the TV — that path only closes the cast dialog UI.
     this.stopCastSession();
     this.playerAv.release();
     this.watcher.clearAll();
@@ -209,6 +214,15 @@ export struct VideoPlayer {
         this.playerAv.setMuted(isMuted);
         this.gestures.pan.primeVolume(this.audioBridge.max > 0 ? vol / this.audioBridge.max : 0);
       });
+      // Wake / page show while still casting: resume progress sync only; do not re-cast
+      // and do not resume local AVPlayer (TV is the playback surface).
+      if (this.castSession.active || this.castConnectedUsn) {
+        this.pageWasHidden = false;
+        this.state.stalled = false;
+        this.syncFromState();
+        this.resumeCastSync();
+        return;
+      }
       if (!this.pageWasHidden || !this.videoUrl || this.state.completed || this.state.errorText) return;
       this.pageWasHidden = false;
       this.state.stalled = false;
@@ -219,7 +233,11 @@ export struct VideoPlayer {
       this.state.stalled = false;
       this.watcher.clearHide();
       this.closeSpeedDialog();
+      // Close cast *dialog* only — keep castDevice / connectedUsn / session; TV keeps playing.
       this.closeCastDialog();
+      if (this.castSession.active) {
+        this.castSession.startPoll(2000);
+      }
       this.syncFromState();
       if (this.state.currentTime > 0) this.state.emitProgress(this.onProgress, true);
       if (this.state.isPlaying) this.playerAv.pause();
@@ -346,10 +364,20 @@ export struct VideoPlayer {
   private closeSpeedDialog(): void { this.speedCtrl.setShowing(false); this.speedOpenSeq = 0; }
   private openCastDialog(): void {
     this.closeSpeedDialog();
+    // Sheet owns interactive 1s poll while open; pause background poll to avoid double traffic.
+    if (this.castSession.active) {
+      this.castSession.stopPoll();
+    }
     this.castOpenSeq += 1;
     this.pulseHud();
   }
-  private closeCastDialog(): void { this.castOpenSeq = 0; }
+  private closeCastDialog(): void {
+    this.castOpenSeq = 0;
+    // Dialog closed (screen-off / dismiss): keep session, resume lightweight bg poll.
+    if (this.castSession.active) {
+      this.castSession.startPoll(2000);
+    }
+  }
   private pauseForCast(): void {
     if (this.state.playRequested || this.state.isPlaying) {
       this.state.playRequested = false;
@@ -361,10 +389,37 @@ export struct VideoPlayer {
       this.watcher.clearHide();
     }
   }
-  private stopCastSession(): void {
-    const device: DlnaDevice | null = this.castDevice;
+  private resumeCastSync(): void {
+    if (!this.castSession.active) {
+      if (this.castDevice) {
+        this.castSession.attach(this.castDevice);
+      } else {
+        return;
+      }
+    }
+    // Sheet open → dialog polls; otherwise keep bg poll for fresh reopen / chip.
+    if (this.castOpenSeq > 0) {
+      this.castSession.stopPoll();
+    } else {
+      this.castSession.startPoll(2000);
+      this.castSession.refreshVolume();
+    }
+  }
+  private bindCastDevice(device: DlnaDevice): void {
+    this.castDevice = device;
+    this.castDeviceName = device.friendlyName;
+    this.castConnectedUsn = device.usn;
+    this.castSession.attach(device);
+  }
+  private clearCastLocal(): void {
     this.castDevice = null;
     this.castDeviceName = '';
+    this.castConnectedUsn = '';
+    this.castSession.clearLocal();
+  }
+  private stopCastSession(): void {
+    const device: DlnaDevice | null = this.castDevice || this.castSession.device;
+    this.clearCastLocal();
     if (!device) {
       return;
     }
@@ -501,15 +556,19 @@ export struct VideoPlayer {
         openSeq: this.castOpenSeq,
         mediaUrl: this.videoUrl,
         mediaTitle: this.title,
+        connectedUsn: $castConnectedUsn,
+        seedDevice: this.castDevice,
+        seedPosition: this.castSession.positionSec,
+        seedDuration: this.castSession.durationSec,
+        seedVolume: this.castSession.volume,
+        seedVolumeSupported: this.castSession.volumeSupported,
         onCasted: (device: DlnaDevice) => {
-          this.castDevice = device;
-          this.castDeviceName = device.friendlyName;
+          this.bindCastDevice(device);
           this.pauseForCast();
           this.pulseHud();
         },
         onStopped: () => {
-          this.castDevice = null;
-          this.castDeviceName = '';
+          this.clearCastLocal();
           this.pulseHud();
         },
         onClosed: () => this.closeCastDialog()
@@ -526,6 +585,27 @@ export struct VideoPlayer {
         topInset: this.topInset, leftInset: this.leftInset, rightInset: this.rightInset, bottomInset: this.bottomInset,
         edgeHud: this.edgeHud, ready: this.ready, events: this.skinEvents()
       })
+
+      // Optional HUD chip while casting — sheet not required; tap reopens controls.
+      if (this.castDeviceName && this.showHud) {
+        Row() {
+          Text(`正在投屏 · ${this.castDeviceName}`)
+            .fontSize(12)
+            .fontWeight(FontWeight.Medium)
+            .fontColor('#FFFFFF')
+            .maxLines(1)
+            .textOverflow({ overflow: TextOverflow.Ellipsis })
+        }
+        .constraintSize({ maxWidth: '72%' })
+        .padding({ left: 10, right: 10, top: 6, bottom: 6 })
+        .backgroundColor(AppTheme.ACCENT_SOFT)
+        .borderRadius(AppTheme.RADIUS_PILL)
+        .margin({
+          top: (this.edgeHud ? this.topInset : this.topInset) + 44,
+          left: this.leftInset + 12
+        })
+        .onClick(() => this.openCastDialog())
+      }
     }
     .width('100%')
     .height('100%')

--- a/entry/src/main/ets/components/VideoPlayer.ets
+++ b/entry/src/main/ets/components/VideoPlayer.ets
@@ -13,7 +13,8 @@ import { PlayerPlaybackState } from './PlayerPlaybackState';
 import { PlayerSkinEvents, PlayerSkinView } from './PlayerSkinView';
 import { PlayerObserverHost, PlayerVideoObserver } from './PlayerVideoObserver';
 import { PlayerSpeedSheet } from './PlayerSpeedSheet';
-import { PlayerCastSheet } from './PlayerCastSheet';
+import { markCastStartSec, peekCastStartSec, PlayerCastSheet } from './PlayerCastSheet';
+import { PlayerCastHud } from './PlayerCastHud';
 import { DlnaClient } from '../common/utils/DlnaClient';
 import { DlnaDevice } from '../common/utils/DlnaTypes';
 import { CastSession } from '../common/utils/CastSession';
@@ -79,6 +80,10 @@ export struct VideoPlayer {
   @State private castDeviceName: string = '';
   @State private castConnectedUsn: string = '';
   @State private castDevice: DlnaDevice | null = null;
+  @State private castStartSec: number = 0;
+  private pausedForPicker: boolean = false;
+  /** Phone was playing when the picker opened; restore this on auto-exit / fail. */
+  private castWasPlaying: boolean = false;
 
   private playerAv: PlayerAv = new PlayerAv();
   private watcher: PlayerStallWatcher = new PlayerStallWatcher();
@@ -92,12 +97,15 @@ export struct VideoPlayer {
   private playerW: number = 1;
   private playerH: number = 1;
   private volumeSub: (() => void) | null = null;
+  private lastCastVolPct: number = -1;
+  private castVolBusy: boolean = false;
+  private endingCast: boolean = false;
   private castClient: DlnaClient = new DlnaClient();
   private castSession: CastSession = new CastSession();
 
   aboutToAppear() {
-    this.castSession.onRemoteDisconnected = () => {
-      this.handleRemoteCastDisconnect();
+    this.castSession.onRemoteDisconnected = (positionSec: number) => {
+      this.handleRemoteCastDisconnect(positionSec);
     };
     this.observer = new PlayerVideoObserver(this.observerHost());
     this.setupPlayerAvListener();
@@ -126,6 +134,7 @@ export struct VideoPlayer {
       this.muted = this.audioBridge.muted;
       this.playerAv.setMuted(this.muted);
       this.gestures.pan.primeVolume(info.max > 0 ? info.current / info.max : 0);
+      this.pushCastVolume();
     });
   }
 
@@ -159,7 +168,8 @@ export struct VideoPlayer {
     this.watcher.clearAll();
     this.closeSpeedDialog();
     this.state.bootGen++;
-    if (this.currentTime > 0) this.state.emitProgress(this.onProgress, true);
+    this.syncCastProgressToState();
+    if (this.state.currentTime > 0) this.state.emitProgress(this.onProgress, true);
     const ctx = this.ctx();
     PlayerWindow.resetBrightness(ctx);
     PlayerWindow.setKeepScreenOn(ctx, false);
@@ -238,9 +248,7 @@ export struct VideoPlayer {
       this.closeSpeedDialog();
       // Close cast *dialog* only — keep castDevice / connectedUsn / session; TV keeps playing.
       this.closeCastDialog();
-      if (this.castSession.active) {
-        this.castSession.startPoll(2000);
-      }
+      this.syncCastProgressToState();
       this.syncFromState();
       if (this.state.currentTime > 0) this.state.emitProgress(this.onProgress, true);
       if (this.state.isPlaying) this.playerAv.pause();
@@ -260,6 +268,9 @@ export struct VideoPlayer {
   }
 
   private togglePlay(): void {
+    if (this.isCasting()) {
+      return;
+    }
     const now = Date.now();
     if (now - this.state.lastToggleAt < VideoPlayer.PLAY_TOGGLE_DEBOUNCE_MS) return;
     this.state.lastToggleAt = now;
@@ -277,8 +288,20 @@ export struct VideoPlayer {
     }
   }
 
+  private isCasting(): boolean {
+    return !!this.castConnectedUsn || !!this.castDeviceName || this.castSession.active;
+  }
+
   private toggleFull(): void {
     const next = !this.fullNow();
+    if (next && this.isCasting()) {
+      try {
+        this.getUIContext().getPromptAction().showToast({ message: '投屏中无法全屏，请先停止投屏' });
+      } catch (_e) {
+      }
+      return;
+    }
+    this.closeCastDialog();
     const isPort = this.state.isPortrait();
     console.info(`[VideoPlayer] 点击全屏 -> targetFull: ${next}, isPortrait: ${isPort}, dimensions: ${this.state.videoWidth}x${this.state.videoHeight}`);
     this.innerFull = next;
@@ -299,6 +322,7 @@ export struct VideoPlayer {
     this.muted = res.muted;
     this.playerAv.setMuted(this.muted);
     this.gestures.pan.primeVolume(this.audioBridge.max > 0 ? res.volume / this.audioBridge.max : 0);
+    this.pushCastVolume();
     this.watcher.showTip(res.label, PlayerTipKind.VOLUME, (msg, k) => { this.feedback = msg; this.feedbackKind = k; }, () => { this.feedback = ''; this.feedbackKind = PlayerTipKind.NONE; });
     this.pulseHud();
   }
@@ -365,32 +389,102 @@ export struct VideoPlayer {
 
   private openSpeedDialog(): void { this.speedCtrl.setShowing(true); this.speedOpenSeq += 1; }
   private closeSpeedDialog(): void { this.speedCtrl.setShowing(false); this.speedOpenSeq = 0; }
+  private logicalPlayhead(): number {
+    const live: number = this.state.currentTime;
+    const hist: number = this.initialTime;
+    if (this.state.ready && live >= 1) {
+      return live;
+    }
+    return Math.max(live, hist, 0);
+  }
+
   private openCastDialog(): void {
+    if (this.fullNow()) {
+      return;
+    }
     this.closeSpeedDialog();
-    // Sheet owns interactive 1s poll while open; pause background poll to avoid double traffic.
-    if (this.castSession.active) {
-      this.castSession.stopPoll();
+    this.castStartSec = this.logicalPlayhead();
+    markCastStartSec(this.castStartSec);
+    this.castWasPlaying = this.state.playRequested && !this.state.errorText && !this.state.completed;
+    console.info(`[VideoPlayer] cast snapshot startSec=${this.castStartSec} current=${this.state.currentTime} initial=${this.initialTime} wasPlaying=${this.castWasPlaying}`);
+    if (this.castWasPlaying) {
+      this.pausedForPicker = true;
+      this.state.playRequested = false;
+      this.state.isPlaying = false;
+      this.playerAv.pause();
+      this.syncFromState();
     }
     this.castOpenSeq += 1;
     this.pulseHud();
   }
   private closeCastDialog(): void {
     this.castOpenSeq = 0;
-    // Dialog closed (screen-off / dismiss): keep session, resume lightweight bg poll.
-    if (this.castSession.active) {
-      this.castSession.startPoll(2000);
-    }
+    this.resumeAfterPickerCancel();
   }
-  private pauseForCast(): void {
-    if (this.state.playRequested || this.state.isPlaying) {
-      this.state.playRequested = false;
-      this.state.isPlaying = false;
-      this.playerAv.pause();
-      this.syncFromState();
-      this.syncKeepScreen();
-      this.showHud = true;
-      this.watcher.clearHide();
+
+  private resumeAfterPickerCancel(): void {
+    if (!this.pausedForPicker || this.isCasting()) {
+      this.pausedForPicker = false;
+      return;
     }
+    this.pausedForPicker = false;
+    this.state.playRequested = true;
+    this.playerAv.play();
+    this.syncFromState();
+  }
+
+  private hudOwnsPoll(): boolean {
+    return !!this.castDeviceName && !this.fullNow();
+  }
+
+  private syncCastProgressToState(): void {
+    if (!this.isCasting()) {
+      return;
+    }
+    const p: number = this.castSession.positionSec;
+    const d: number = this.castSession.durationSec;
+    if (p > 0) {
+      this.state.currentTime = p;
+    }
+    if (d > 0) {
+      this.state.duration = d;
+    }
+    this.syncFromState();
+  }
+  /** Tear down local AVPlayer while TV is the playback surface (Bilibili-style). */
+  private parkPlayerForCast(): void {
+    this.watcher.clearOpenWatch();
+    this.watcher.clearSeekWatch();
+    this.watcher.clearHide();
+    this.state.bootGen += 1;
+    this.state.playerOn = false;
+    this.state.errorText = '';
+    this.state.opening = false;
+    this.state.stalled = false;
+    this.state.playRequested = false;
+    this.state.isPlaying = false;
+    this.state.ready = false;
+    this.state.seeking = false;
+    this.playerAv.release();
+    this.syncFromState();
+    this.syncKeepScreen();
+    this.showHud = true;
+  }
+
+  private resumePlayerAfterCast(resumeAt: number, resumePlay: boolean = true): void {
+    const t: number = Math.max(0, resumeAt);
+    this.state.currentTime = t;
+    this.state.pendingResumeSec = t;
+    this.state.errorText = '';
+    this.state.completed = false;
+    this.state.stalled = false;
+    this.state.playRequested = resumePlay;
+    this.state.isPlaying = false;
+    this.state.ready = false;
+    this.state.opening = !!this.videoUrl;
+    this.syncFromState();
+    this.showHud = true;
+    this.remountPlayer();
   }
   private resumeCastSync(): void {
     if (!this.castSession.active) {
@@ -400,34 +494,114 @@ export struct VideoPlayer {
         return;
       }
     }
-    // Sheet open → dialog polls; otherwise keep bg poll for fresh reopen / chip.
-    if (this.castOpenSeq > 0) {
+    if (this.hudOwnsPoll()) {
       this.castSession.stopPoll();
-    } else {
-      this.castSession.startPoll(2000);
-      this.castSession.refreshVolume();
+      return;
     }
+    this.castSession.startPoll(2000);
+    this.castSession.refreshVolume();
   }
   private bindCastDevice(device: DlnaDevice): void {
     this.castDevice = device;
     this.castDeviceName = device.friendlyName;
     this.castConnectedUsn = device.usn;
     this.castSession.attach(device);
+    const start: number = Math.max(this.castStartSec, peekCastStartSec(), this.state.currentTime);
+    this.castSession.positionSec = start;
+    this.castSession.durationSec = this.state.duration;
+    console.info(`[VideoPlayer] bindCast start=${start} dur=${this.state.duration}`);
+    this.lastCastVolPct = -1;
+    this.pushCastVolume();
+    this.exitFullForCast();
+  }
+
+  /** Map phone MEDIA volume 0–max → TV RenderingControl 0–100. No HUD slider. */
+  private pushCastVolume(): void {
+    if (!this.isCasting()) {
+      return;
+    }
+    const device: DlnaDevice | null = this.castDevice;
+    if (!device || !device.renderingControlURL) {
+      return;
+    }
+    const max: number = Math.max(1, this.audioBridge.max);
+    const pct: number = Math.max(0, Math.min(100, Math.round(this.volumeIndex / max * 100)));
+    if (pct === this.lastCastVolPct || this.castVolBusy) {
+      return;
+    }
+    this.lastCastVolPct = pct;
+    this.castVolBusy = true;
+    this.castClient.setVolume(device, pct).then(() => {
+      this.castVolBusy = false;
+      const latest: number = Math.max(0, Math.min(100, Math.round(this.volumeIndex / max * 100)));
+      if (latest !== this.lastCastVolPct) {
+        this.pushCastVolume();
+      }
+    }).catch((err: Object) => {
+      this.castVolBusy = false;
+      console.info(`[VideoPlayer] cast volume skip: ${JSON.stringify(err)}`);
+    });
+  }
+
+  private exitFullForCast(): void {
+    if (!this.fullNow()) {
+      return;
+    }
+    this.innerFull = false;
+    const isPort = this.state.isPortrait();
+    if (this.onFullscreenChange) {
+      this.onFullscreenChange(false, isPort);
+    } else {
+      PlayerWindow.setFullscreen(this.ctx(), false, isPort);
+    }
   }
   private clearCastLocal(): void {
     this.castDevice = null;
     this.castDeviceName = '';
     this.castConnectedUsn = '';
+    this.lastCastVolPct = -1;
+    this.castVolBusy = false;
     this.castSession.clearLocal();
   }
   /** TV stopped / powered off / network drop — local clear only, no Stop SOAP. */
-  private handleRemoteCastDisconnect(): void {
+  private handleRemoteCastDisconnect(resumeAt: number): void {
+    if (this.endingCast) {
+      return;
+    }
+    this.endingCast = true;
     this.clearCastLocal();
     this.closeCastDialog();
+    this.resumePlayerAfterCast(resumeAt, this.castWasPlaying);
     try {
       this.getUIContext().getPromptAction().showToast({ message: '电视已停止投屏' });
     } catch (_e) {
     }
+    this.endingCast = false;
+    this.pulseHud();
+  }
+
+  /** SetURI/Play 成功但电视未真正起播，或进度/状态一直无效。 */
+  private handleCastPlaybackFailed(resumeAt: number): void {
+    if (this.endingCast) {
+      return;
+    }
+    this.endingCast = true;
+    const device: DlnaDevice | null = this.castDevice || this.castSession.device;
+    const play: boolean = this.castWasPlaying;
+    const pos: number = Math.max(resumeAt, this.castStartSec, this.state.currentTime);
+    this.clearCastLocal();
+    this.closeCastDialog();
+    if (device) {
+      this.castClient.stop(device).catch((err: Object) => {
+        console.error(`[VideoPlayer] fail-stop: ${JSON.stringify(err)}`);
+      });
+    }
+    this.resumePlayerAfterCast(pos, play);
+    try {
+      this.getUIContext().getPromptAction().showToast({ message: '投屏失败，已回到手机' });
+    } catch (_e) {
+    }
+    this.endingCast = false;
     this.pulseHud();
   }
   private stopCastSession(): void {
@@ -439,6 +613,29 @@ export struct VideoPlayer {
     this.castClient.stop(device).catch((err: Object) => {
       console.error(`[VideoPlayer] cast stop failed: ${JSON.stringify(err)}`);
     });
+  }
+
+  private async endCastByUser(): Promise<void> {
+    if (this.endingCast || !this.isCasting()) {
+      return;
+    }
+    this.endingCast = true;
+    const device: DlnaDevice | null = this.castDevice || this.castSession.device;
+    const pos: number = Math.max(this.castSession.positionSec, this.state.currentTime);
+    this.clearCastLocal();
+    try {
+      if (device) {
+        await this.castClient.stop(device);
+      }
+    } catch (err) {
+      console.error(`[VideoPlayer] end cast failed: ${JSON.stringify(err)}`);
+    }
+    this.endingCast = false;
+    this.resumePlayerAfterCast(pos, this.castWasPlaying);
+    try {
+      this.getUIContext().getPromptAction().showToast({ message: '已停止投屏' });
+    } catch (_e) {
+    }
   }
   private cycleScaleMode(): void {
     const next = this.scaleCtrl.cycle();
@@ -513,6 +710,9 @@ export struct VideoPlayer {
         }
       },
       onLongPress: () => {
+        if (this.isCasting()) {
+          return;
+        }
         if (this.speedCtrl.beginFastForward(this.state.canPlay(), this.isPlaying)) {
           this.longPressing = true; this.speedIndex = this.speedCtrl.index; this.speedLabel = this.speedCtrl.label;
           this.playerAv.setSpeedIndex(this.speedIndex);
@@ -525,9 +725,15 @@ export struct VideoPlayer {
           this.playerAv.setSpeedIndex(this.speedIndex); this.pulseHud();
         }
       },
-      onPanStart: (e) => this.gestures.start(e, this.state.canPlay(), this.longPressing, this.currentTime, this.playerW, this.ctx()),
+      onPanStart: (e) => {
+        if (this.isCasting()) {
+          return;
+        }
+        this.gestures.start(e, this.state.canPlay(), this.longPressing, this.currentTime, this.playerW, this.ctx());
+      },
       onPanMove: (e) => this.panMove(e), onPanEnd: () => this.finishPanSeek(), onPanCancel: () => this.finishPanSeek(),
-      onCast: () => this.openCastDialog()
+      onCast: () => this.openCastDialog(),
+      onStopCast: () => this.endCastByUser()
     };
   }
 
@@ -565,28 +771,40 @@ export struct VideoPlayer {
         onClosed: () => this.speedCtrl.setShowing(false)
       })
 
-      PlayerCastSheet({
-        openSeq: this.castOpenSeq,
-        mediaUrl: this.videoUrl,
-        mediaTitle: this.title,
-        connectedUsn: $castConnectedUsn,
-        seedDevice: this.castDevice,
-        seedPosition: this.castSession.positionSec,
-        seedDuration: this.castSession.durationSec,
-        seedVolume: this.castSession.volume,
-        seedVolumeSupported: this.castSession.volumeSupported,
-        castSession: this.castSession,
-        onCasted: (device: DlnaDevice) => {
-          this.bindCastDevice(device);
-          this.pauseForCast();
-          this.pulseHud();
-        },
-        onStopped: () => {
-          this.clearCastLocal();
-          this.pulseHud();
-        },
-        onClosed: () => this.closeCastDialog()
-      })
+      if (this.castDeviceName && !this.fullNow()) {
+        Column() {
+          PlayerCastHud({
+            deviceName: this.castDeviceName,
+            seedDuration: this.duration,
+            seedDevice: this.castDevice,
+            castSession: this.castSession,
+            onStopped: (positionSec: number) => {
+              this.clearCastLocal();
+              this.resumePlayerAfterCast(positionSec, this.castWasPlaying);
+            },
+            onFailed: (positionSec: number) => {
+              this.handleCastPlaybackFailed(positionSec);
+            },
+            onProgress: (positionSec: number, durationSec: number) => {
+              if (positionSec > 0) {
+                this.state.currentTime = positionSec;
+              }
+              if (durationSec > 0) {
+                this.state.duration = durationSec;
+              }
+              this.syncFromState();
+              this.state.emitProgress(this.onProgress, false);
+            }
+          })
+        }
+        .width('100%')
+        .height('100%')
+        .justifyContent(FlexAlign.Center)
+        .alignItems(HorizontalAlign.Center)
+        .padding({ top: 12 })
+        .hitTestBehavior(HitTestMode.Transparent)
+        .zIndex(20)
+      }
 
       PlayerSkinView({
         isFull: this.fullNow(), showHud: this.showHud, showBack: this.showBack, title: this.title,
@@ -597,29 +815,32 @@ export struct VideoPlayer {
         hasPrev: this.hasPrev, hasNext: this.hasNext, longPressing: this.longPressing,
         feedback: this.feedback, feedbackKind: this.feedbackKind,
         topInset: this.topInset, leftInset: this.leftInset, rightInset: this.rightInset, bottomInset: this.bottomInset,
-        edgeHud: this.edgeHud, ready: this.ready, events: this.skinEvents()
+        edgeHud: this.edgeHud, ready: this.ready, castDeviceName: this.castDeviceName,
+        events: this.skinEvents()
       })
+        .width('100%')
+        .height('100%')
+        .hitTestBehavior(HitTestMode.Transparent)
+        .zIndex(80)
 
-      // Optional HUD chip while casting — sheet not required; tap reopens controls.
-      if (this.castDeviceName && this.showHud) {
-        Row() {
-          Text(`正在投屏 · ${this.castDeviceName}`)
-            .fontSize(12)
-            .fontWeight(FontWeight.Medium)
-            .fontColor('#FFFFFF')
-            .maxLines(1)
-            .textOverflow({ overflow: TextOverflow.Ellipsis })
-        }
-        .constraintSize({ maxWidth: '72%' })
-        .padding({ left: 10, right: 10, top: 6, bottom: 6 })
-        .backgroundColor(AppTheme.ACCENT_SOFT)
-        .borderRadius(AppTheme.RADIUS_PILL)
-        .margin({
-          top: (this.edgeHud ? this.topInset : this.topInset) + 44,
-          left: this.leftInset + 12
-        })
-        .onClick(() => this.openCastDialog())
-      }
+      PlayerCastSheet({
+        openSeq: this.castOpenSeq,
+        mediaUrl: this.videoUrl,
+        mediaTitle: this.title,
+        startPosition: this.castStartSec,
+        startDuration: this.state.duration,
+        getStartPosition: () => this.castStartSec > 0 ? this.castStartSec : this.logicalPlayhead(),
+        connectedUsn: this.castConnectedUsn,
+        seedDevice: this.castDevice,
+        onCasted: (device: DlnaDevice) => {
+          this.pausedForPicker = false;
+          this.bindCastDevice(device);
+          this.parkPlayerForCast();
+          this.closeCastDialog();
+          this.pulseHud();
+        },
+        onClosed: () => this.closeCastDialog()
+      })
     }
     .width('100%')
     .height('100%')

--- a/entry/src/main/ets/components/VideoPlayer.ets
+++ b/entry/src/main/ets/components/VideoPlayer.ets
@@ -13,11 +13,10 @@ import { PlayerPlaybackState } from './PlayerPlaybackState';
 import { PlayerSkinEvents, PlayerSkinView } from './PlayerSkinView';
 import { PlayerObserverHost, PlayerVideoObserver } from './PlayerVideoObserver';
 import { PlayerSpeedSheet } from './PlayerSpeedSheet';
-import { markCastStartSec, peekCastStartSec, PlayerCastSheet } from './PlayerCastSheet';
+import { PlayerCastSheet } from './PlayerCastSheet';
 import { PlayerCastHud } from './PlayerCastHud';
-import { DlnaClient } from '../common/utils/DlnaClient';
+import { PlayerCastController, PlayerCastHost } from './PlayerCastController';
 import { DlnaDevice } from '../common/utils/DlnaTypes';
-import { CastSession } from '../common/utils/CastSession';
 import { PlayerScale, PlayerScaleMode } from '../common/utils/PlayerScale';
 import { PlayerScaleController } from './PlayerScaleController';
 import { PlayerAv } from '../common/utils/PlayerAv';
@@ -81,9 +80,8 @@ export struct VideoPlayer {
   @State private castConnectedUsn: string = '';
   @State private castDevice: DlnaDevice | null = null;
   @State private castStartSec: number = 0;
-  private pausedForPicker: boolean = false;
-  /** Phone was playing when the picker opened; restore this on auto-exit / fail. */
-  private castWasPlaying: boolean = false;
+  @State private castPhase: string = '';
+  @State private castTransport: string = '';
 
   private playerAv: PlayerAv = new PlayerAv();
   private watcher: PlayerStallWatcher = new PlayerStallWatcher();
@@ -97,16 +95,11 @@ export struct VideoPlayer {
   private playerW: number = 1;
   private playerH: number = 1;
   private volumeSub: (() => void) | null = null;
-  private lastCastVolPct: number = -1;
-  private castVolBusy: boolean = false;
-  private endingCast: boolean = false;
-  private castClient: DlnaClient = new DlnaClient();
-  private castSession: CastSession = new CastSession();
+  private castCtrl: PlayerCastController = new PlayerCastController();
 
   aboutToAppear() {
-    this.castSession.onRemoteDisconnected = (positionSec: number) => {
-      this.handleRemoteCastDisconnect(positionSec);
-    };
+    this.castCtrl.updateHost(this.castHost());
+    this.castCtrl.bindCallbacks();
     this.observer = new PlayerVideoObserver(this.observerHost());
     this.setupPlayerAvListener();
     this.nonce = 1;
@@ -163,12 +156,12 @@ export struct VideoPlayer {
     this.closeCastDialog();
     // True leave of PlayPage (navigate away). Screen-off uses onPageHide → pageActive=false
     // and must NOT Stop the TV — that path only closes the cast dialog UI.
-    this.stopCastSession();
+    this.ctrl().stopSession();
     this.playerAv.release();
     this.watcher.clearAll();
     this.closeSpeedDialog();
     this.state.bootGen++;
-    this.syncCastProgressToState();
+    this.ctrl().syncCastProgressToState();
     if (this.state.currentTime > 0) this.state.emitProgress(this.onProgress, true);
     const ctx = this.ctx();
     PlayerWindow.resetBrightness(ctx);
@@ -178,8 +171,17 @@ export struct VideoPlayer {
     }
   }
 
-  onUrlChange(): void { this.resetPlayState(); this.remountPlayer(); }
-  onReloadTokenChange(): void { this.resetPlayState(); this.remountPlayer(); }
+  onUrlChange(): void { this.handleSourceChange(); }
+  onReloadTokenChange(): void { this.handleSourceChange(); }
+
+  private handleSourceChange(): void {
+    if (this.ctrl().handleSourceChange()) {
+      this.syncCastUi();
+      return;
+    }
+    this.resetPlayState();
+    this.remountPlayer();
+  }
 
   private observerHost(): PlayerObserverHost {
     return {
@@ -229,11 +231,11 @@ export struct VideoPlayer {
       });
       // Wake / page show while still casting: resume progress sync only; do not re-cast
       // and do not resume local AVPlayer (TV is the playback surface).
-      if (this.castSession.active || this.castConnectedUsn) {
+      if (this.ctrl().isCasting() || this.castConnectedUsn) {
         this.pageWasHidden = false;
         this.state.stalled = false;
         this.syncFromState();
-        this.resumeCastSync();
+        this.ctrl().resumeCastSync();
         return;
       }
       if (!this.pageWasHidden || !this.videoUrl || this.state.completed || this.state.errorText) return;
@@ -248,7 +250,7 @@ export struct VideoPlayer {
       this.closeSpeedDialog();
       // Close cast *dialog* only — keep castDevice / connectedUsn / session; TV keeps playing.
       this.closeCastDialog();
-      this.syncCastProgressToState();
+      this.ctrl().syncCastProgressToState();
       this.syncFromState();
       if (this.state.currentTime > 0) this.state.emitProgress(this.onProgress, true);
       if (this.state.isPlaying) this.playerAv.pause();
@@ -289,7 +291,7 @@ export struct VideoPlayer {
   }
 
   private isCasting(): boolean {
-    return !!this.castConnectedUsn || !!this.castDeviceName || this.castSession.active;
+    return this.castCtrl.isCasting();
   }
 
   private toggleFull(): void {
@@ -398,245 +400,86 @@ export struct VideoPlayer {
     return Math.max(live, hist, 0);
   }
 
-  private openCastDialog(): void {
-    if (this.fullNow()) {
-      return;
-    }
-    this.closeSpeedDialog();
-    this.castStartSec = this.logicalPlayhead();
-    markCastStartSec(this.castStartSec);
-    this.castWasPlaying = this.state.playRequested && !this.state.errorText && !this.state.completed;
-    console.info(`[VideoPlayer] cast snapshot startSec=${this.castStartSec} current=${this.state.currentTime} initial=${this.initialTime} wasPlaying=${this.castWasPlaying}`);
-    if (this.castWasPlaying) {
-      this.pausedForPicker = true;
-      this.state.playRequested = false;
-      this.state.isPlaying = false;
-      this.playerAv.pause();
-      this.syncFromState();
-    }
-    this.castOpenSeq += 1;
-    this.pulseHud();
+  private ctrl(): PlayerCastController {
+    this.castCtrl.updateHost(this.castHost());
+    return this.castCtrl;
   }
+
+  private castHost(): PlayerCastHost {
+    return {
+      state: this.state,
+      playerAv: this.playerAv,
+      watcher: this.watcher,
+      audioBridge: this.audioBridge,
+      videoUrl: this.videoUrl,
+      title: this.title,
+      hasNext: () => this.hasNext,
+      volumeIndex: this.volumeIndex,
+      onEnded: this.onEnded,
+      onProgress: this.onProgress,
+      syncFromState: () => this.syncFromState(),
+      syncKeepScreen: () => this.syncKeepScreen(),
+      remountPlayer: () => this.remountPlayer(),
+      pulseHud: () => this.pulseHud(),
+      closeCastDialog: () => this.closeCastDialog(),
+      closeSpeedDialog: () => this.closeSpeedDialog(),
+      openCastSheet: () => {
+        this.castOpenSeq += 1;
+      },
+      onCastUi: () => this.syncCastUi(),
+      toast: (msg: string) => {
+        try {
+          this.getUIContext().getPromptAction().showToast({ message: msg });
+        } catch (_e) {
+        }
+      },
+      fullNow: () => this.fullNow(),
+      exitFullForCast: () => {
+        if (!this.fullNow()) {
+          return;
+        }
+        this.innerFull = false;
+        const isPort: boolean = this.state.isPortrait();
+        if (this.onFullscreenChange) {
+          this.onFullscreenChange(false, isPort);
+        } else {
+          PlayerWindow.setFullscreen(this.ctx(), false, isPort);
+        }
+      },
+      logicalPlayhead: () => this.logicalPlayhead()
+    };
+  }
+
+  private syncCastUi(): void {
+    this.castDevice = this.castCtrl.device;
+    this.castDeviceName = this.castCtrl.deviceName;
+    this.castConnectedUsn = this.castCtrl.connectedUsn;
+    this.castStartSec = this.castCtrl.startSec;
+    this.castPhase = this.castCtrl.session.phase;
+    this.castTransport = this.castCtrl.session.transportState;
+    this.currentTime = this.castCtrl.session.positionSec;
+    this.duration = this.castCtrl.session.durationSec > 0 ?
+      this.castCtrl.session.durationSec : this.duration;
+  }
+
+  private openCastDialog(): void {
+    this.ctrl().openCastDialog();
+    this.syncCastUi();
+  }
+
   private closeCastDialog(): void {
     this.castOpenSeq = 0;
-    this.resumeAfterPickerCancel();
+    this.ctrl().resumeAfterPickerCancel();
   }
 
-  private resumeAfterPickerCancel(): void {
-    if (!this.pausedForPicker || this.isCasting()) {
-      this.pausedForPicker = false;
-      return;
-    }
-    this.pausedForPicker = false;
-    this.state.playRequested = true;
-    this.playerAv.play();
-    this.syncFromState();
-  }
-
-  private hudOwnsPoll(): boolean {
-    return !!this.castDeviceName && !this.fullNow();
-  }
-
-  private syncCastProgressToState(): void {
-    if (!this.isCasting()) {
-      return;
-    }
-    const p: number = this.castSession.positionSec;
-    const d: number = this.castSession.durationSec;
-    if (p > 0) {
-      this.state.currentTime = p;
-    }
-    if (d > 0) {
-      this.state.duration = d;
-    }
-    this.syncFromState();
-  }
-  /** Tear down local AVPlayer while TV is the playback surface (Bilibili-style). */
-  private parkPlayerForCast(): void {
-    this.watcher.clearOpenWatch();
-    this.watcher.clearSeekWatch();
-    this.watcher.clearHide();
-    this.state.bootGen += 1;
-    this.state.playerOn = false;
-    this.state.errorText = '';
-    this.state.opening = false;
-    this.state.stalled = false;
-    this.state.playRequested = false;
-    this.state.isPlaying = false;
-    this.state.ready = false;
-    this.state.seeking = false;
-    this.playerAv.release();
-    this.syncFromState();
-    this.syncKeepScreen();
-    this.showHud = true;
-  }
-
-  private resumePlayerAfterCast(resumeAt: number, resumePlay: boolean = true): void {
-    const t: number = Math.max(0, resumeAt);
-    this.state.currentTime = t;
-    this.state.pendingResumeSec = t;
-    this.state.errorText = '';
-    this.state.completed = false;
-    this.state.stalled = false;
-    this.state.playRequested = resumePlay;
-    this.state.isPlaying = false;
-    this.state.ready = false;
-    this.state.opening = !!this.videoUrl;
-    this.syncFromState();
-    this.showHud = true;
-    this.remountPlayer();
-  }
-  private resumeCastSync(): void {
-    if (!this.castSession.active) {
-      if (this.castDevice) {
-        this.castSession.attach(this.castDevice);
-      } else {
-        return;
-      }
-    }
-    if (this.hudOwnsPoll()) {
-      this.castSession.stopPoll();
-      return;
-    }
-    this.castSession.startPoll(2000);
-    this.castSession.refreshVolume();
-  }
-  private bindCastDevice(device: DlnaDevice): void {
-    this.castDevice = device;
-    this.castDeviceName = device.friendlyName;
-    this.castConnectedUsn = device.usn;
-    this.castSession.attach(device);
-    const start: number = Math.max(this.castStartSec, peekCastStartSec(), this.state.currentTime);
-    this.castSession.positionSec = start;
-    this.castSession.durationSec = this.state.duration;
-    console.info(`[VideoPlayer] bindCast start=${start} dur=${this.state.duration}`);
-    this.lastCastVolPct = -1;
-    this.pushCastVolume();
-    this.exitFullForCast();
-  }
-
-  /** Map phone MEDIA volume 0–max → TV RenderingControl 0–100. No HUD slider. */
   private pushCastVolume(): void {
-    if (!this.isCasting()) {
-      return;
-    }
-    const device: DlnaDevice | null = this.castDevice;
-    if (!device || !device.renderingControlURL) {
-      return;
-    }
-    const max: number = Math.max(1, this.audioBridge.max);
-    const pct: number = Math.max(0, Math.min(100, Math.round(this.volumeIndex / max * 100)));
-    if (pct === this.lastCastVolPct || this.castVolBusy) {
-      return;
-    }
-    this.lastCastVolPct = pct;
-    this.castVolBusy = true;
-    this.castClient.setVolume(device, pct).then(() => {
-      this.castVolBusy = false;
-      const latest: number = Math.max(0, Math.min(100, Math.round(this.volumeIndex / max * 100)));
-      if (latest !== this.lastCastVolPct) {
-        this.pushCastVolume();
-      }
-    }).catch((err: Object) => {
-      this.castVolBusy = false;
-      console.info(`[VideoPlayer] cast volume skip: ${JSON.stringify(err)}`);
-    });
+    this.ctrl().pushCastVolume();
   }
 
-  private exitFullForCast(): void {
-    if (!this.fullNow()) {
-      return;
-    }
-    this.innerFull = false;
-    const isPort = this.state.isPortrait();
-    if (this.onFullscreenChange) {
-      this.onFullscreenChange(false, isPort);
-    } else {
-      PlayerWindow.setFullscreen(this.ctx(), false, isPort);
-    }
-  }
-  private clearCastLocal(): void {
-    this.castDevice = null;
-    this.castDeviceName = '';
-    this.castConnectedUsn = '';
-    this.lastCastVolPct = -1;
-    this.castVolBusy = false;
-    this.castSession.clearLocal();
-  }
-  /** TV stopped / powered off / network drop — local clear only, no Stop SOAP. */
-  private handleRemoteCastDisconnect(resumeAt: number): void {
-    if (this.endingCast) {
-      return;
-    }
-    this.endingCast = true;
-    this.clearCastLocal();
-    this.closeCastDialog();
-    this.resumePlayerAfterCast(resumeAt, this.castWasPlaying);
-    try {
-      this.getUIContext().getPromptAction().showToast({ message: '电视已停止投屏' });
-    } catch (_e) {
-    }
-    this.endingCast = false;
-    this.pulseHud();
+  private endCastByUser(): void {
+    this.ctrl().endCastByUser();
   }
 
-  /** SetURI/Play 成功但电视未真正起播，或进度/状态一直无效。 */
-  private handleCastPlaybackFailed(resumeAt: number): void {
-    if (this.endingCast) {
-      return;
-    }
-    this.endingCast = true;
-    const device: DlnaDevice | null = this.castDevice || this.castSession.device;
-    const play: boolean = this.castWasPlaying;
-    const pos: number = Math.max(resumeAt, this.castStartSec, this.state.currentTime);
-    this.clearCastLocal();
-    this.closeCastDialog();
-    if (device) {
-      this.castClient.stop(device).catch((err: Object) => {
-        console.error(`[VideoPlayer] fail-stop: ${JSON.stringify(err)}`);
-      });
-    }
-    this.resumePlayerAfterCast(pos, play);
-    try {
-      this.getUIContext().getPromptAction().showToast({ message: '投屏失败，已回到手机' });
-    } catch (_e) {
-    }
-    this.endingCast = false;
-    this.pulseHud();
-  }
-  private stopCastSession(): void {
-    const device: DlnaDevice | null = this.castDevice || this.castSession.device;
-    this.clearCastLocal();
-    if (!device) {
-      return;
-    }
-    this.castClient.stop(device).catch((err: Object) => {
-      console.error(`[VideoPlayer] cast stop failed: ${JSON.stringify(err)}`);
-    });
-  }
-
-  private async endCastByUser(): Promise<void> {
-    if (this.endingCast || !this.isCasting()) {
-      return;
-    }
-    this.endingCast = true;
-    const device: DlnaDevice | null = this.castDevice || this.castSession.device;
-    const pos: number = Math.max(this.castSession.positionSec, this.state.currentTime);
-    this.clearCastLocal();
-    try {
-      if (device) {
-        await this.castClient.stop(device);
-      }
-    } catch (err) {
-      console.error(`[VideoPlayer] end cast failed: ${JSON.stringify(err)}`);
-    }
-    this.endingCast = false;
-    this.resumePlayerAfterCast(pos, this.castWasPlaying);
-    try {
-      this.getUIContext().getPromptAction().showToast({ message: '已停止投屏' });
-    } catch (_e) {
-    }
-  }
   private cycleScaleMode(): void {
     const next = this.scaleCtrl.cycle();
     this.scaleMode = next;
@@ -775,26 +618,11 @@ export struct VideoPlayer {
         Column() {
           PlayerCastHud({
             deviceName: this.castDeviceName,
-            seedDuration: this.duration,
-            seedDevice: this.castDevice,
-            castSession: this.castSession,
-            onStopped: (positionSec: number) => {
-              this.clearCastLocal();
-              this.resumePlayerAfterCast(positionSec, this.castWasPlaying);
-            },
-            onFailed: (positionSec: number) => {
-              this.handleCastPlaybackFailed(positionSec);
-            },
-            onProgress: (positionSec: number, durationSec: number) => {
-              if (positionSec > 0) {
-                this.state.currentTime = positionSec;
-              }
-              if (durationSec > 0) {
-                this.state.duration = durationSec;
-              }
-              this.syncFromState();
-              this.state.emitProgress(this.onProgress, false);
-            }
+            positionSec: this.currentTime,
+            durationSec: this.duration,
+            phase: this.castPhase,
+            transportState: this.castTransport,
+            castSession: this.castCtrl.session
           })
         }
         .width('100%')
@@ -833,11 +661,8 @@ export struct VideoPlayer {
         connectedUsn: this.castConnectedUsn,
         seedDevice: this.castDevice,
         onCasted: (device: DlnaDevice) => {
-          this.pausedForPicker = false;
-          this.bindCastDevice(device);
-          this.parkPlayerForCast();
-          this.closeCastDialog();
-          this.pulseHud();
+          this.ctrl().bindCastDevice(device);
+          this.syncCastUi();
         },
         onClosed: () => this.closeCastDialog()
       })

--- a/entry/src/main/module.json5
+++ b/entry/src/main/module.json5
@@ -40,6 +40,9 @@
       },
       {
         "name": "ohos.permission.GET_NETWORK_INFO"
+      },
+      {
+        "name": "ohos.permission.GET_WIFI_INFO"
       }
     ],
     "metadata": [

--- a/投屏实现方案.md
+++ b/投屏实现方案.md
@@ -1,0 +1,501 @@
+# DLNA 投屏实现方案
+
+本文是 `feat/dlna-cast` 的落地规格。实现时按本文改代码，不按旧 HUD 的固定 12s 判定。
+
+产品一句话：**播放页只有一套连播规则——有下一集就自动播；投屏只决定下一集还在不在电视上。**
+
+不实现 GENA / LastChange 订阅。不提交 `build-profile.json5`。不引入新依赖。
+
+---
+
+## 1. 产品规则
+
+与本机 `PlayPage` 对齐：
+
+```368:368:entry/src/main/ets/pages/PlayPage.ets
+      onEnded: () => { if (this.hasNext()) this.playNext(); },
+```
+
+`hasNext` = 当前线路 `episodeIndex < linkList.length - 1`。投屏不得另写一套切集规则。
+
+| 场景 | 行为 |
+|---|---|
+| 本机播完且有下一集 | `onEnded` → `playNext()`（已有） |
+| 电视播完且有下一集 | 同一出口：`onEnded` → `playNext()`，**自动续投同一设备**（本机继续 park，不 remount AVPlayer） |
+| 电视播完且无下一集 | 退出 HUD，本机 `completed`，不 Stop 以外的额外 SOAP（电视已 STOPPED） |
+| 手动点选集 / 点「下一集」「上一集」 | **不续投**：Stop 电视 → 本机播新集 |
+| 用户点红色电源 | Stop 电视 → 按电视进度回手机，恢复投屏前暂停/播放 |
+| SetURI / Play SOAP 失败 | 立刻退出投屏，回到手机，恢复投屏前暂停/播放 |
+| 起播后电视无 PLAYING/TRANSITIONING（超时兜底） | 同上 fail-back |
+| RelTime 为 `NOT_IMPLEMENTED` | 信 TransportState；HUD 可用本地走表；**不能判片尾**，STOPPED 当遥控器停，回手机 |
+
+禁止：停投后把本机 seek 到片尾再赌 `handleFinish`。AVPlayer 投屏时已 park，`handleFinish` 不会触发。
+
+---
+
+## 2. 现状问题（必须改掉）
+
+1. **起播确认靠固定 12s**（`PlayerCastHud.CONFIRM_TIMEOUT_MS`）+ STOPPED×5≥8s。慢盒子会误杀；SOAP Play 成功 ≠ 电视起播。
+2. **Stop 路径分散**：HUD `failCast` / HUD `stopCast` / `VideoPlayer.handleSourceChange` / `handleCastPlaybackFailed` / `endCastByUser` / `stopCastSession` / Picker dismiss 各自 `DlnaClient.stop`。`CastSession.stopRemote` 几乎没被当作唯一入口。
+3. **电视 STOPPED 一律当掉线**：`CastSession.noteTransportState` 在 `everPlayed` 后 STOPPED×3 → `handleRemoteDisconnect` 回手机。自然播完也会走这条，**吞掉 `onEnded`/`playNext`**。
+4. **切集一律停投**：`VideoPlayer.handleSourceChange` 在投屏中改 URL 就 Stop + remount。自动下一集无法续投。
+5. **双轮询**：HUD 1s + Session 2s，职责重叠。
+6. **SOAP Fault** 只当失败字符串，不解析 `errorCode`，无法秒失败。
+7. 文件已超标：`VideoPlayer.ets` 872 行、`DlnaClient.ets` 685 行。投屏编排禁止继续堆进 `VideoPlayer`。
+
+---
+
+## 3. 目标架构
+
+```
+PlayPage
+  onEnded / playNext / hasNext     ← 唯一连播规则，不改语义
+       │
+VideoPlayer + PlayerCastController  ← park/resume 本机；keepCastForNext；绑定回调
+       │
+CastSession                         ← 唯一会话：设备、状态机、轮询、Stop、片尾/掉线
+       │
+DlnaClient                          ← SOAP；解析 Fault.errorCode
+       │
+PlayerCastHud                       ← 只展示 + 暂停/拖动；不拥有 poll，不直接 Stop
+```
+
+原则：
+
+- **CastSession 是唯一 Stop / 轮询 / 起播判定 / 片尾判定的地方。**
+- HUD 订阅 session 状态，发 `pause`/`play`/`seek`/`userStop` 请求。
+- 本机 AVPlayer 投屏期间保持 park。
+- `PlayPage.ets` 的 `onEnded` 一行不改。
+
+---
+
+## 4. 状态机
+
+### 4.1 会话阶段（CastSession.phase）
+
+用字符串常量，不引入新枚举文件以外的类型即可（可放 `DlnaTypes.ets`）：
+
+```
+idle → launching → playing → paused
+                 ↘ failed
+playing/paused → completed   （自然片尾）
+playing/paused → disconnected（遥控器停 / 网络掉）
+任意 → stopping → idle       （用户电源键 / 手动切集）
+```
+
+| phase | 含义 |
+|---|---|
+| `idle` | 无设备 |
+| `launching` | 已 SetURI+Play，等 Transport 起播 |
+| `playing` | 已确认 PLAYING（或等价） |
+| `paused` | `PAUSED_PLAYBACK` |
+| `completed` | 确认播完当前 URI |
+| `failed` | 起播失败，即将 fail-back |
+| `disconnected` | 起播后遥控器停或轮询连续失败 |
+| `stopping` | 正在发 Stop |
+
+HUD 文案：
+
+- `launching` → 「正在连接…」
+- `playing` → 「播放中」
+- `paused` → 「已暂停」
+- `TRANSITIONING` 且仍 `launching`/`playing` → 「缓冲中」
+
+### 4.2 起播确认（主信号 = Transport，超时只兜底）
+
+`SetAVTransportURI` + `Play` HTTP 200 **不算成功**。进入 `launching`，轮询 `GetTransportInfo`（主）+ `GetPositionInfo`（旁证）。
+
+**立刻确认（→ `playing` / `paused`）：**
+
+- `CurrentTransportState` ∈ { `PLAYING`, `PAUSED_PLAYBACK` }
+- 或 `TRANSITIONING` 之后落到上述其一
+- 旁证：`RelTime` 解析出 `positionSec > 0`（仅当 RelTime 可用）
+
+`TRANSITIONING` 本身：保持 `launching`，**不失败**，只刷新「缓冲中」。
+
+**立刻失败（→ `failed`，不等超时）：**
+
+- SetURI / Play 的 SOAP Fault，且 `errorCode` 属于致命表（见 §5）
+- HTTP 4xx/5xx 且无 body 可解析时，同样失败
+- TransportState = `ERROR`
+
+**超时兜底（仅 `launching` 且从未确认）：**
+
+```
+timeoutMs = matchSlowDevice(device) ? 35000 : 20000
+```
+
+超时仍无 PLAYING/PAUSED/RelTime>0 → `failed`。
+
+`launching` 期间看到 `STOPPED` / `NO_MEDIA_PRESENT`：**不要立刻失败**（部分盒子 SetURI 后短暂 STOPPED）。若持续到超时仍是 STOPPED → `failed`。
+
+禁止再使用 HUD 里的 12s / 8s / STOPPED×5 作为主路径。
+
+### 4.3 慢盒子白名单
+
+放 `CastSession` 顶部常量，按 `manufacturer` / `friendlyName` 子串匹配（大小写不敏感）：
+
+```
+SLOW_NAME_SUBSTR = ['macast', 'kodi', 'mpv', 'xbmc']
+```
+
+命中 → 起播超时 35s；未命中 → 20s。名单只服务超时，不改变确认条件。后续真机补条目，不预埋一堆品牌。
+
+### 4.4 RelTime 不可用
+
+连续 ≥3 次 `GetPositionInfo` 成功，但 `RelTime` 为：
+
+- 空
+- `NOT_IMPLEMENTED`
+- `NOT_IMPLEMENTED.` 一类变体（trim + 大写后 `indexOf('NOT_IMPLEMENTED') === 0`）
+
+则 `relTimeUnavailable = true`。
+
+之后：
+
+- 确认 / 暂停 / 失败只信 TransportState
+- HUD：`PLAYING` 时用本地走表（现有 `originMs` 逻辑搬到 session 或 HUD 只读 session.positionSec）
+- **禁止用进度判片尾**
+- 起播后 STOPPED → 走 `disconnected`（当遥控器停），回手机
+- toast 一次：「设备不支持进度同步」（沿用现逻辑，不要每秒弹）
+
+---
+
+## 5. SOAP 错误码
+
+### 5.1 解析
+
+`DlnaClient.soapAction` 在 HTTP 非 2xx **或** body 含 `Fault` 时，解析：
+
+```xml
+<errorCode>714</errorCode>
+<errorDescription>...</errorDescription>
+```
+
+用现有 `extractTag`。抛出结构化错误（放 `DlnaTypes.ets`，避免新文件）：
+
+```ets
+export class DlnaSoapError {
+  action: string = '';
+  httpCode: number = 0;
+  errorCode: number = 0;   // 解析失败为 0
+  errorDescription: string = '';
+}
+```
+
+`message` 仍可给人看：`投屏指令失败 (SetAVTransportURI, 714)`。
+
+ArkTS 对 `extends Error` 不友好：用普通 class，catch 后用 `err instanceof DlnaSoapError` 或鸭子判断 `errorCode`。
+
+### 5.2 致命 vs 可忽略
+
+仅对 **SetAVTransportURI / Play** 立刻失败：
+
+| errorCode | 含义 | 处理 |
+|---|---|---|
+| 714 | Illegal MIME-type | 立刻 failed |
+| 716 | Resource not found | 立刻 failed |
+| 401 | Invalid Action | 立刻 failed |
+| 402 | Invalid Args | 立刻 failed |
+| 701 | Transition not available | Play/SetURI 上立刻 failed；Seek 上忽略 |
+| 0 + HTTP≥400 | 无码 | SetURI/Play 立刻 failed |
+
+**Seek / Pause / Stop / Get\***：不升级为投屏失败。Seek 失败 toast「设备不支持进度拖动」（已有）。Stop 失败只打日志。
+
+Picker 里 SetURI/Play 抛错：现有 toast 路径保留，不进入 session。
+
+---
+
+## 6. 播完 / 掉线 / 切集
+
+### 6.1 自然片尾（completed）
+
+条件（全部满足）：
+
+1. phase 已是 `playing` 或 `paused`（曾经确认起播）
+2. `relTimeUnavailable === false`
+3. `durationSec > 1` 且 `positionSec >= durationSec - 3`
+4. Transport ∈ { `STOPPED`, `NO_MEDIA_PRESENT` }（同一 tick 或紧接着 1 个 tick，防抖；**不要等 STOPPED×3**）
+
+然后：
+
+```
+phase = completed
+clearLocal 暂不调用（设备还要续投下集）
+callback onCompleted()
+```
+
+`VideoPlayer` / `PlayerCastController`：
+
+```
+if (this.hasNext && this.onEnded) {
+  this.keepCastForNext = true;
+  this.onEnded();          // PlayPage.playNext()
+} else {
+  this.finishCastCompleted();  // 清 HUD，本机 completed，不 Play
+}
+```
+
+不要 `resumePlayerAfterCast(duration)`。
+
+### 6.2 遥控器停 / 网络掉（disconnected）
+
+条件：已确认起播，且 **不是** §6.1：
+
+- Transport `STOPPED`/`NO_MEDIA_PRESENT` 连续 3 tick
+- 或 GetPositionInfo+GetTransportInfo **都失败** 连续 3 tick（现 `FAIL_THRESHOLD`）
+
+→ `clearLocal()`（**不发 Stop**）→ `onDisconnected(positionSec)` → 本机按该进度续播，播放/暂停用 `castWasPlaying`。
+
+### 6.3 自动续投 vs 手动切集
+
+`selectEpisode` 会改 `playUrl` + `playToken`，触发 `VideoPlayer.handleSourceChange`。用一帧内的标志区分：
+
+```
+handleSourceChange():
+  if (keepCastForNext && isCasting()) {
+    keepCastForNext = false
+    recastCurrentUrl()      // 同一设备 SetURI+Play，startSec=0
+    return                  // 不 remount
+  }
+  if (isCasting() && !endingCast) {
+    session.stopRemote()    // 手动切集
+    clearCastLocal()
+  }
+  resetPlayState()
+  remountPlayer()
+```
+
+`onUrlChange` 与 `onReloadTokenChange` 都会进这里：**续投只执行一次**（flag 消费后即清）。
+
+`recastCurrentUrl`：
+
+1. 校验 `castSession.device` 仍在
+2. `phase = launching`，清 pending/confirm/position（新集从 0）
+3. HUD 保持挂载（`castDeviceName` 不空）
+4. `client.cast(device, videoUrl, title, 0, 0)`（或 session 封装 `replaceUri`）
+5. 失败 → 按 fail-back：Stop 已不必（可能没播起来），本机 remount 播新集，toast「续投失败，已在手机播放」
+
+手动「下一集」走 `onNext` → `playNext`，**不会**置 `keepCastForNext`，因此停投回手机。这是有意的：自动片尾才续投。
+
+### 6.4 用户结束投屏
+
+顶栏红色电源 → `session.stopRemote()` → 按电视进度 `resumePlayerAfterCast(pos, castWasPlaying)`。
+
+HUD 不再自己 `client.stop`。
+
+---
+
+## 7. Stop 收口
+
+唯一发 Stop SOAP 的方法：`CastSession.stopRemote()`。
+
+| 调用方 | 调用 | 是否 Stop SOAP |
+|---|---|---|
+| 红色电源 | `stopRemote()` | 是 |
+| 手动切集 | `stopRemote()` | 是 |
+| 起播失败 / SOAP 致命错 | `stopRemote()` 或先 Stop 再 clear | 是（尽力） |
+| 离开 PlayPage | `stopRemote()` | 是 |
+| 片尾 completed | 不 Stop | 否 |
+| 遥控器停 / 轮询掉线 | `clearLocal()` | 否 |
+| Picker 点选后用户立刻关掉 | 现有 `client.stop` 改为同一 `DlnaClient.stop` 即可（此时 session 可能尚未 attach）；不要再开第三条业务路径 |
+
+HUD `failCast` / `stopCast` 改为只回调，由 Controller/Session 执行。
+
+禁止 HUD 与 VideoPlayer 连续 Stop 两次（现状：`failCast` stop + `handleCastPlaybackFailed` 再 stop）。
+
+---
+
+## 8. 分文件改动
+
+### 8.1 `DlnaTypes.ets`
+
+新增 `DlnaSoapError`、`CastPhase` 字符串常量（或 enum）。`DlnaPositionInfo` 可加 `relTimeRaw`（已有 `relTime` 字段则复用）。
+
+### 8.2 `DlnaClient.ets`
+
+- `soapAction`：Fault / 非 2xx → 填 `DlnaSoapError` 再 throw
+- `getPositionInfo`：原样返回 raw `RelTime`（已有）
+- 不在 Client 里做状态机
+- 文件已 685 行：本次只改 `soapAction` + 错误类，**不顺手拆文件**（除非本任务必须碰到且会再涨）
+
+### 8.3 `CastSession.ets`（核心，目标仍 ≤500）
+
+现 255 行，可容纳状态机。职责扩成：
+
+```
+attach / clearLocal / stopRemote          （已有，Stop 成为唯一入口）
+replaceUri(url, title, startSec)          （自动续投：SetURI+Play，reset launching）
+startPoll / stopPoll                      （HUD 在时 1s，HUD 消失 2s）
+tick：GetTransportInfo + GetPositionInfo
+判定 launching 确认 / 超时 / ERROR
+判定 completed vs disconnected
+relTimeUnavailable 计数
+onFailed / onCompleted / onDisconnected / onState
+  回调由 Controller 注入
+```
+
+删除「STOPPED×3 一律 disconnect」中与片尾冲突的部分，改为 §6 分支。
+
+`attach` 不要把调用方刚写入的 `positionSec`/`durationSec` 清掉——现状 `attach` 置 0，续播靠 HUD `peekCastStartSec` 补。改为：`attach` 只设 device；进度由 `bind`/`replaceUri` 显式赋值。
+
+若实现后超过 500 行：把 poll tick 抽 `CastSessionPoll.ets`，不要塞进 VideoPlayer。
+
+### 8.4 新建 `PlayerCastController.ets`
+
+从 `VideoPlayer.ets` 抽出投屏编排（否则 872 行还要加续投，必超标）：
+
+- `openCastDialog` / `bindCastDevice` / `parkPlayerForCast`
+- `resumePlayerAfterCast` / `handleCastPlaybackFailed`
+- `endCastByUser` / `handleSourceChange` 的投屏分支
+- `keepCastForNext` + `recastCurrentUrl`
+- `handleCastCompleted` / `handleCastDisconnected`
+- 音量 `pushCastVolume`（现逻辑原样搬）
+
+`VideoPlayer` 只保留：是否投屏的 UI 开关、把 HUD/皮肤事件转给 Controller。
+
+### 8.5 `PlayerCastHud.ets`
+
+变成纯 UI：
+
+- 去掉自建 `setInterval` poll、`judgePlayback`、`failCast` 里的 `client.stop`
+- 读 `castSession.phase` / `positionSec` / `durationSec` / `transportState`
+- 暂停/拖动仍调 `DlnaClient` **或** session 封装的 `play`/`pause`/`seek`（推荐走 session，避免第三个 client）
+- 用户点停：`onUserStop()` 回调，不直接 Stop
+- `aboutToAppear`：`session.setHudPolling(true)`（1s）
+- `aboutToDisappear`：`session.setHudPolling(false)`（2s 后台 poll）
+
+目标从 495 行降到展示+按钮。
+
+### 8.6 `VideoPlayer.ets`
+
+- 投屏方法迁走后应明显瘦身
+- HUD：`onFailed`/`onStopped`/`onProgress` 接 Controller
+- 增加 completed 回调通道
+- `handleSourceChange` 只调 Controller
+- `hasNext` 已有 `@Prop`，completed 时用它决定是否 `onEnded`
+
+### 8.7 `PlayerCastSheet.ets`
+
+- `castTo` 成功后 `onCasted` 不变
+- SetURI/Play 抛 `DlnaSoapError`：toast 用 `errorDescription` 或现成 message
+- dismiss 中途 Stop 保持（session 尚未 attach）
+- Seek 仍不在 picker 里做（已迁 HUD/session）
+
+### 8.8 `PlayPage.ets`
+
+**不改** `onEnded` / `playNext` / `hasNext`。
+
+### 8.9 不改
+
+- 液态玻璃 HUD、红色电源、音量跟本机 MEDIA、全屏禁投屏、点选立刻 toast、历史/续播、`NoticeDialog`
+- GENA
+- `build-profile.json5`
+
+---
+
+## 9. 关键时序
+
+### 9.1 首次投屏
+
+```
+用户选设备
+  → toast「正在投屏到 xx」
+  → SetURI + Play
+  → SOAP 致命错：toast + 不 attach
+  → 成功：bind + park AVPlayer + HUD
+  → session.phase=launching，poll GetTransportInfo
+  → PLAYING：phase=playing，若 pendingStart≥2 且 duration 已知则 Seek
+  → 超时/ERROR：stopRemote + 本机按 castWasPlaying 恢复
+```
+
+### 9.2 电视播完有下一集
+
+```
+poll: pos≈dur 且 STOPPED
+  → onCompleted
+  → keepCastForNext=true
+  → onEnded() → playNext() → url/token 变
+  → handleSourceChange 吃掉 flag
+  → replaceUri(新 url) ，phase=launching
+  → 本机仍 park，HUD 仍在，标题随 playTitle 更新
+  → 再次确认 PLAYING
+```
+
+### 9.3 电视播完无下一集
+
+```
+onCompleted
+  → hasNext=false，不调 onEnded
+  → clearLocal（不 Stop）
+  → 本机 completed UI（可 remount 到片尾暂停，或只展示完成态，不自动播放）
+```
+
+### 9.4 手动切集
+
+```
+点选集 / 皮肤下一集
+  → playNext/selectEpisode（keepCastForNext=false）
+  → stopRemote + remount 本机播新集
+```
+
+---
+
+## 10. 实现顺序
+
+按依赖，每步可独立验证：
+
+1. **SOAP errorCode**（`DlnaClient` + `DlnaTypes`）  
+   验证：非法 URL / 拒收 MIME 立刻 toast，不进 HUD。
+2. **Stop 收口到 `CastSession.stopRemote`**  
+   验证：电源键、失败回退、离开页、手动切集只打一条 Stop 日志。
+3. **起播状态机 + 慢盒超时 + RelTime 旁证**（取代 HUD 12s）  
+   验证：Macast 慢起播不被 12s 误杀；ERROR/714 秒退；RelTime NI 时 PLAYING 仍确认。
+4. **抽出 `PlayerCastController`，HUD 去掉独立 poll**  
+   验证：后台/回前台进度仍在；HUD 暂停与电视同步。
+5. **片尾 → onEnded → 自动续投；手动切集仍停投**  
+   验证：见 §11。
+
+不要先做 5 再做 3：没有可靠 completed，续投会误触发。
+
+---
+
+## 11. 验收
+
+| # | 步骤 | 期望 |
+|---|---|---|
+| 1 | 本机播完有下一集 | 自动下一集（回归，与投屏无关） |
+| 2 | 投屏成功后电视 PLAYING | HUD 非 00:00；本机无声画面（park） |
+| 3 | 慢盒 15s 才 PLAYING | 不 fail-back |
+| 4 | SetURI 714 / Play Fault | 立刻回手机，保持投屏前暂停/播放 |
+| 5 | RelTime NOT_IMPLEMENTED 但 PLAYING | 确认成功；进度可走表；电视停 → 回手机，不切集 |
+| 6 | 电视自然播完，有下一集 | 同一设备自动播下一集；HUD 仍在；本机不起来 |
+| 7 | 电视自然播完，最后一集 | HUD 关；本机完成态；不切集 |
+| 8 | 投屏中点选集 | 电视 Stop；本机播所选集 |
+| 9 | 投屏中点皮肤「下一集」 | 同 8，不续投 |
+| 10 | 红色电源 | 电视停；手机从电视进度续 |
+| 11 | 续投下集 SetURI 失败 | 本机播放该集，toast 续投失败 |
+| 12 | 全屏 | 无投屏入口；投屏中不能全屏 |
+
+无法上真机时：至少保证编译通过，并打日志覆盖 phase 变迁（`launching`/`playing`/`completed`/`failed`）。在回复里写明未真机验证的项。
+
+---
+
+## 12. 明确不做
+
+- GENA / `LastChange` 事件订阅
+- 投屏中倍速
+- HUD 音量条（音量继续跟本机 MEDIA）
+- 手动切集后仍留在电视
+- 用本机 `handleFinish` 冒充电视播完
+- 预埋多设备多房间、投屏队列
+- 改签名 / `build-profile.json5`
+
+---
+
+## 13. 风险
+
+- **无 RelTime 的盒子无法自动切集**：只能当遥控器。这是协议限制，不要用「STOPPED 就当播完」猜，会把用户按停误切下一集。
+- **部分盒子播完停在 PAUSED 或停在最后一帧仍 PLAYING**：无 STOPPED 则本轮不切集。不要靠「进度卡住 N 秒」猜 EOS（和起播缓冲分不清）。真机若大量出现，再单开补丁，不写进本轮。
+- **`onUrlChange` + `onReloadTokenChange` 双触发**：`keepCastForNext` 必须一次性消费。
+- **续投 SetURI 时电视可能仍占着旧 URI**：`replaceUri` 前可发一次 Stop，失败忽略，再 SetURI+Play。


### PR DESCRIPTION
## Summary
为 OHOS 播放器补齐 DLNA/UPnP MediaRenderer 投屏：局域网发现设备、投当前播放地址、停止投屏，并在已连接态同步远端进度与音量控制。锁屏 / 短暂切后台时会话保活，电视继续播；回到前台恢复进度/音量同步。

## What was added
- **SSDP 发现**：`DlnaClient` 通过 UDP / Multicast 发送 `M-SEARCH`（`urn:schemas-upnp-org:device:MediaRenderer:1`），解析 `LOCATION`，拉取设备描述 XML，定位 `AVTransport` / `RenderingControl` `controlURL`。
- **投屏控制**：`SetAVTransportURI` + `Play`；支持 `Stop` / 断开。
- **进度同步**：已连接时弹层约 1s 轮询 `GetPositionInfo`（可选 `GetTransportInfo`）；弹层关闭后由 `CastSession` 约 2s 轻量轮询保活；拖动进度条发送 `Seek`（`REL_TIME`）。
- **音量控制**：解析设备描述中的 `RenderingControl`；`GetVolume` / `SetVolume`（`Master`）；弹层滑条与 ±5 按钮；不支持时 toast，不崩溃。
- **会话保活（screen-off）**：`pageActive=false`（锁屏 / onPageHide）只关投屏弹层 UI，**不** `Stop` 电视、不清除 `castDevice` / `connectedUsn`；`pageActive=true` 时若仍在投屏则 `resumeCastSync`，不重投、不恢复本地 AVPlayer。`Stop` 仅在弹层「停止投屏」或真正离开 PlayPage（`VideoPlayer.aboutToDisappear`）。
- **UI**：`PlayerCastSheet` 底部弹层；播放器 HUD 可选 chip「正在投屏 · 设备名」（点按重开弹层）。
- **接线**：`PlayerSkin` 投屏按钮 → `VideoPlayer`；`connectedUsn` `@Link` 到播放器；投屏成功后暂停本地 `AVPlayer`。
- **权限**：新增 `ohos.permission.GET_WIFI_INFO`；已有 `INTERNET` / `GET_NETWORK_INFO`。

## How to test
1. 手机与电视/盒子连同一 Wi‑Fi。
2. 打开播放页，点投屏图标，选设备；确认电视开始播放，本地暂停；HUD 出现「正在投屏 · …」chip。
3. **锁屏**：锁手机屏幕约 10–30s → 电视应继续播放（不应停）。
4. **解锁**：回到播放页 → 点投屏按钮或 chip 打开弹层 → 进度/音量仍可用（无需重新投屏）。
5. 拖动进度条 / 调音量，确认电视响应。
6. 点「停止投屏」→ 电视停止；或返回离开 PlayPage → 电视停止。

## Known limitations / renderer quirks
- 部分盒子 `TrackDuration`/`RelTime` 返回 `NOT_IMPLEMENTED` 或 `0:00:00` → 进度条不可用或卡在 0。
- 少数机型不支持 `Seek`/`REL_TIME` 或只支持 `ABS_TIME`。
- 无 `RenderingControl` 或 `GetVolume` 失败时隐藏音量条并 toast。
- 部分盒子对媒体格式 / `DIDL-Lite` metadata 较挑剔。
- SSDP 依赖局域网组播；访客网络 / 隔离 AP 可能扫不到设备。
- 深睡眠时系统可能暂停定时器/网络；解锁后会恢复轮询。未做多设备并发投屏。
