### PR TITLE
feat: 增加独立关于页面、收敛版本更新入口并重构影视详情与剧情排版

### DIFF
--- a/entry/src/main/ets/common/constants/AppTheme.ets
+++ b/entry/src/main/ets/common/constants/AppTheme.ets
@@ -11,6 +11,7 @@ export class AppTheme {
   static readonly TEXT_SECONDARY = 'rgba(255, 255, 255, 0.65)';
   static readonly TEXT_MUTED = 'rgba(255, 255, 255, 0.40)';
   static readonly BORDER = 'rgba(255, 255, 255, 0.08)';
+  static readonly BORDER_SOLID = '#262832';
   static readonly OVERLAY = 'rgba(10, 11, 16, 0.55)';
 
   static readonly SPACE_XS = 4;

--- a/entry/src/main/ets/common/utils/FormatUtil.ets
+++ b/entry/src/main/ets/common/utils/FormatUtil.ets
@@ -18,6 +18,29 @@ export class FormatUtil {
     return text.length >= 4 ? text.slice(0, 4) : text;
   }
 
+  static remarks(value: string | number | undefined | null): string {
+    const text = FormatUtil.text(value);
+    if (!text) {
+      return '';
+    }
+    if (text.startsWith('更新至') || text.startsWith('全') || text.endsWith('全') || text === '完结') {
+      return text;
+    }
+    const epMatch = text.match(/^第\s*(\d+)\s*集$/);
+    if (epMatch) {
+      return `更新至${epMatch[1]}集`;
+    }
+    const numMatch = text.match(/^(\d+)\s*集$/);
+    if (numMatch) {
+      return `更新至${numMatch[1]}集`;
+    }
+    const updateMatch = text.match(/^更新第?\s*(\d+)\s*集$/);
+    if (updateMatch) {
+      return `更新至${updateMatch[1]}集`;
+    }
+    return text;
+  }
+
   static poster(film: MovieBasicInfo): string {
     const raw = film.picture || film.poster || film.pictureSlide || '';
     return ServerConfigManager.getInstance().resolveMediaUrl(raw);
@@ -127,5 +150,47 @@ export class FormatUtil {
 
   static tagBorder(id: number, name: string = ''): string {
     return FormatUtil.TAG_BORDER[FormatUtil.tagIndex(id, name)];
+  }
+
+  /**
+   * 深度清洗 HTML 剧情简介文本：
+   * 1. 结构化标签转为换行符
+   * 2. 剥除所有 HTML/脚本/样式标签
+   * 3. 完整解码各种空格与符号转义实体（&emsp;, &nbsp;, \u3000 等）
+   * 4. 彻底修剪每一行的段首段尾恶意缩进与错位空格
+   * 5. 以双换行规范段落间距，呈现整洁的移动端阅读排版
+   */
+  static cleanPlot(raw: string): string {
+    if (!raw) {
+      return '';
+    }
+    const text = raw
+      .replace(/<\s*br\s*\/?>/gi, '\n')
+      .replace(/<\s*\/(p|div|li|tr|h[1-6])\s*>/gi, '\n\n')
+      .replace(/<script[\s\S]*?<\/script>/gi, '')
+      .replace(/<style[\s\S]*?<\/style>/gi, '')
+      .replace(/<[^>]+>/g, '')
+      .replace(/&emsp;/gi, ' ')
+      .replace(/&ensp;/gi, ' ')
+      .replace(/&thinsp;/gi, ' ')
+      .replace(/&nbsp;/gi, ' ')
+      .replace(/&#160;/gi, ' ')
+      .replace(/&#12288;/gi, ' ')
+      .replace(/&quot;/gi, '"')
+      .replace(/&apos;|&#39;/gi, "'")
+      .replace(/&lt;/gi, '<')
+      .replace(/&gt;/gi, '>')
+      .replace(/&amp;/gi, '&');
+
+    const lines = text.split('\n');
+    const cleanedLines: string[] = [];
+    for (let i = 0; i < lines.length; i++) {
+      // 彻底去除每行段首与段尾的普通空格、全角空格(\u3000)、不换行空格(\u00A0)
+      const trimmed = lines[i].replace(/^[\s\u3000\u00A0\u2000-\u200B]+|[\s\u3000\u00A0\u2000-\u200B]+$/g, '');
+      if (trimmed !== '') {
+        cleanedLines.push(trimmed);
+      }
+    }
+    return cleanedLines.join('\n\n');
   }
 }

--- a/entry/src/main/ets/common/utils/NavUtil.ets
+++ b/entry/src/main/ets/common/utils/NavUtil.ets
@@ -64,6 +64,16 @@ export class NavUtil {
     }
   }
 
+  static openAbout(uiContext?: UIContext): void {
+    try {
+      const r = NavUtil.getRouter(uiContext);
+      if (r) {
+        r.pushUrl({ url: 'pages/AboutPage' });
+      }
+    } catch (_e) {
+    }
+  }
+
   static openPlay(id: string | number, sourceId: string = '', episodeIndex?: number,
     currentTime?: number, uiContext?: UIContext): void {
     if (!id && id !== 0) {

--- a/entry/src/main/ets/components/dialogs/FilmDetailDialog.ets
+++ b/entry/src/main/ets/components/dialogs/FilmDetailDialog.ets
@@ -1,5 +1,6 @@
 import { AppTheme } from '../../common/constants/AppTheme';
 import { AppIcon } from '../common/AppIcon';
+import { FormatUtil } from '../../common/utils/FormatUtil';
 
 @CustomDialog
 export struct FilmDetailDialog {
@@ -69,12 +70,14 @@ export struct FilmDetailDialog {
 
       // 影片简要信息卡片
       Column() {
-        // 标题与评分行
+        // 标题与评分行（详情弹窗中片名完整展现，绝不省略）
         Row() {
           Text(this.name)
             .fontSize(16)
             .fontWeight(FontWeight.Bold)
             .fontColor(AppTheme.TEXT_PRIMARY)
+            .lineHeight(22)
+            .textOverflow({ overflow: TextOverflow.None })
             .layoutWeight(1)
 
           if (this.scoreText !== '') {
@@ -97,7 +100,7 @@ export struct FilmDetailDialog {
           }
         }
         .width('100%')
-        .alignItems(VerticalAlign.Center)
+        .alignItems(VerticalAlign.Top)
         .margin({ bottom: this.tags.length > 0 ? 8 : 0 })
 
         // 影视标签组（独立排版，自动折行）
@@ -199,7 +202,7 @@ export struct FilmDetailDialog {
               }
               .alignItems(VerticalAlign.Center)
 
-              Text(this.plot)
+              Text(FormatUtil.cleanPlot(this.plot))
                 .fontSize(13)
                 .fontColor(AppTheme.TEXT_SECONDARY)
                 .lineHeight(22)

--- a/entry/src/main/ets/components/film/FilmDetailHeader.ets
+++ b/entry/src/main/ets/components/film/FilmDetailHeader.ets
@@ -3,6 +3,7 @@ import { AppTheme } from '../../common/constants/AppTheme';
 import { AppIcon } from '../common/AppIcon';
 import { FilmDetailDialog } from '../dialogs/FilmDetailDialog';
 import { FavoriteManager } from '../../services/FavoriteManager';
+import { FormatUtil } from '../../common/utils/FormatUtil';
 
 @Component
 export struct FilmDetailHeader {
@@ -66,16 +67,7 @@ export struct FilmDetailHeader {
 
   private syncDerivedState(): void {
     const raw = this.plot || this.descriptor?.content || this.descriptor?.blurb || '';
-    this.cleanPlot = raw
-      .replace(/<br\s*\/?>/gi, '\n')
-      .replace(/<\/p>/gi, '\n')
-      .replace(/<[^>]+>/g, '')
-      .replace(/&nbsp;/g, ' ')
-      .replace(/&amp;/g, '&')
-      .replace(/&lt;/g, '<')
-      .replace(/&gt;/g, '>')
-      .replace(/\n{3,}/g, '\n\n')
-      .trim();
+    this.cleanPlot = FormatUtil.cleanPlot(raw);
 
     const s = this.descriptor?.dbScore ? this.descriptor.dbScore.trim() : '';
     this.scoreText = (!s || s === '0' || s === '0.0') ? '' : s;
@@ -85,17 +77,29 @@ export struct FilmDetailHeader {
     return this.directorText() !== '' || this.actorText() !== '' || this.cleanPlot !== '';
   }
 
-  private detailSnippetText(): string {
-    if (this.actorText() !== '') {
-      return `主演：${this.actorText()}`;
+  private briefMetaText(): string {
+    const parts: string[] = [];
+    if (this.descriptor?.year && this.descriptor.year.trim()) {
+      parts.push(this.descriptor.year.trim());
     }
-    if (this.directorText() !== '') {
-      return `导演：${this.directorText()}`;
+    const cat = this.descriptor?.classTag || this.descriptor?.cName;
+    if (cat && cat.trim()) {
+      const firstCat = cat.trim().split(/[,/，\s]+/)[0].trim();
+      if (firstCat) {
+        parts.push(firstCat);
+      }
     }
-    if (this.cleanPlot !== '') {
-      return `简介：${this.cleanPlot.replace(/\n+/g, ' ')}`;
+    const rawArea = this.descriptor?.area || this.descriptor?.language;
+    if (rawArea && rawArea.trim()) {
+      const firstArea = rawArea.trim().split(/[,/，\s]+/)[0].trim();
+      if (firstArea) {
+        parts.push(firstArea);
+      }
     }
-    return '查看简介 / 主演 / 导演';
+    if (parts.length === 0) {
+      return '';
+    }
+    return parts.join(' · ');
   }
 
   private metaTagsList(): string[] {
@@ -174,153 +178,102 @@ export struct FilmDetailHeader {
 
   build() {
     Column() {
-      // 1. 标题与收藏操作按钮行
+      // 1. 片名与收藏行（左侧片名最多2行后省略；右上角常驻唯一收藏胶囊，平衡短片名与长片名的视觉重心）
       Row() {
         Text(this.name)
-          .fontSize(19)
+          .fontSize(18)
           .fontWeight(FontWeight.Bold)
           .fontColor(AppTheme.TEXT_PRIMARY)
           .maxLines(2)
           .textOverflow({ overflow: TextOverflow.Ellipsis })
+          .lineHeight(24)
           .layoutWeight(1)
 
-        // 收藏按钮
-        Row() {
+        // 收藏按钮（右上角唯一的实体胶囊，26vp 精致尺寸，顶部对齐）
+        Row({ space: 3 }) {
           AppIcon({
             src: this.isFav ? $r('sys.symbol.star_fill') : $r('sys.symbol.star'),
             iconSize: 13,
-            color: this.isFav ? '#FA8C16' : AppTheme.TEXT_MUTED
+            color: this.isFav ? '#FA8C16' : AppTheme.TEXT_SECONDARY
           })
           Text(this.isFav ? '已收藏' : '收藏')
             .fontSize(12)
             .fontWeight(FontWeight.Medium)
-            .fontColor(this.isFav ? '#FA8C16' : AppTheme.TEXT_MUTED)
-            .margin({ left: 4 })
+            .fontColor(this.isFav ? '#FA8C16' : AppTheme.TEXT_SECONDARY)
         }
-        .padding({ left: 10, right: 10, top: 4, bottom: 4 })
-        .backgroundColor(this.isFav ? 'rgba(250, 140, 22, 0.12)' : AppTheme.BG_CARD)
-        .borderRadius(13)
-        .border({ width: 0.5, color: this.isFav ? 'rgba(250, 140, 22, 0.3)' : AppTheme.BORDER })
+        .height(26)
+        .padding({ left: 9, right: 9 })
+        .backgroundColor(this.isFav ? 'rgba(250, 140, 22, 0.14)' : AppTheme.BG_CARD)
+        .borderRadius(AppTheme.RADIUS_PILL)
+        .border({ width: 0.5, color: this.isFav ? 'rgba(250, 140, 22, 0.35)' : AppTheme.BORDER })
         .margin({ left: 10 })
         .onClick(() => {
           this.handleToggleFavorite();
         })
       }
       .width('100%')
-      .alignItems(VerticalAlign.Center)
-      .padding({ left: 12, right: 12, top: 10 })
+      .alignItems(VerticalAlign.Top)
+      .padding({ left: 12, right: 12, top: 8, bottom: 4 })
 
-      // 2. 元数据行（左侧固定评分徽章，右侧标签支持横向滚动）
-      Row() {
-        // 左侧固定评分徽章
+      // 2. 元数据与简介行（纯信息展示，全靠左自然流式排布，整行点击直达详情弹窗）
+      Row({ space: 6 }) {
+        // 评分微标（如有）
         if (this.scoreText !== '') {
-          Row({ space: 3 }) {
+          Row({ space: 2 }) {
             Text('★')
-              .fontSize(12)
+              .fontSize(10)
               .fontColor(AppTheme.ACCENT)
             Text(this.scoreText)
-              .fontSize(14)
+              .fontSize(12)
               .fontWeight(FontWeight.Bold)
               .fontColor(AppTheme.ACCENT)
             Text('分')
-              .fontSize(10)
+              .fontSize(9)
               .fontColor(AppTheme.ACCENT)
-              .margin({ top: 1 })
           }
-          .padding({ left: 8, right: 8, top: 3, bottom: 3 })
+          .padding({ left: 6, right: 6, top: 2, bottom: 2 })
           .backgroundColor(AppTheme.ACCENT_SOFT)
           .borderRadius(AppTheme.RADIUS_SM)
-          .margin({ right: 8 })
-        } else {
-          Row({ space: 3 }) {
-            Text('★')
-              .fontSize(11)
-              .fontColor(AppTheme.TEXT_MUTED)
-            Text('暂无评分')
-              .fontSize(11)
-              .fontWeight(FontWeight.Medium)
-              .fontColor(AppTheme.TEXT_MUTED)
-          }
-          .padding({ left: 7, right: 7, top: 3, bottom: 3 })
-          .backgroundColor(AppTheme.BG_CHIP)
-          .borderRadius(AppTheme.RADIUS_SM)
-          .margin({ right: 8 })
         }
 
-        // 右侧元数据小胶囊组（可横向滚动）
-        Scroll() {
-          Row({ space: 6 }) {
-            ForEach(this.metaTagsList(), (tag: string) => {
-              Text(tag)
-                .fontSize(11)
-                .fontColor(AppTheme.TEXT_SECONDARY)
-                .padding({ left: 7, right: 7, top: 3, bottom: 3 })
-                .backgroundColor(AppTheme.BG_CHIP)
-                .borderRadius(AppTheme.RADIUS_SM)
-            }, (tag: string) => tag)
-          }
+        // 核心信息摘要（年份 · 分类 · 地区）
+        if (this.briefMetaText() !== '') {
+          Text(this.briefMetaText())
+            .fontSize(12)
+            .fontColor(AppTheme.TEXT_SECONDARY)
+            .maxLines(1)
+            .textOverflow({ overflow: TextOverflow.Ellipsis })
+            .constraintSize({ maxWidth: '65%' })
         }
-        .layoutWeight(1)
-        .scrollable(ScrollDirection.Horizontal)
-        .scrollBar(BarState.Off)
-        .align(Alignment.Start)
-      }
-      .width('100%')
-      .alignItems(VerticalAlign.Center)
-      .padding({ left: 12, right: 12, top: 8 })
 
-      // 3. 详细信息卡片导引条（独立整行大热区，带摘要与高亮详情入口）
-      if (this.hasDetailInfo()) {
-        Row() {
-          Row() {
-            Row({ space: 6 }) {
-              AppIcon({
-                src: $r('sys.symbol.doc_plaintext'),
-                iconSize: 14,
-                color: AppTheme.ACCENT
-              })
-              Text(this.detailSnippetText())
-                .fontSize(12)
-                .fontColor(AppTheme.TEXT_SECONDARY)
-                .maxLines(1)
-                .textOverflow({ overflow: TextOverflow.Ellipsis })
-                .layoutWeight(1)
-            }
-            .layoutWeight(1)
-            .alignItems(VerticalAlign.Center)
-
-            Row({ space: 2 }) {
-              Text('详情')
-                .fontSize(12)
-                .fontWeight(FontWeight.Bold)
-                .fontColor(AppTheme.ACCENT)
-              AppIcon({
-                src: $r('sys.symbol.chevron_right'),
-                iconSize: 12,
-                color: AppTheme.ACCENT
-              })
-            }
-            .padding({ left: 6, right: 4, top: 3, bottom: 3 })
-            .backgroundColor(AppTheme.ACCENT_SOFT)
-            .borderRadius(AppTheme.RADIUS_SM)
-            .alignItems(VerticalAlign.Center)
-            .margin({ left: 8 })
+        // 紧贴左侧的纯文字更多入口（主题高亮色链接，无按钮底色）
+        Row({ space: 1 }) {
+          if (this.briefMetaText() !== '') {
+            Text('· ')
+              .fontSize(12)
+              .fontColor(AppTheme.TEXT_MUTED)
           }
-          .width('100%')
-          .padding({ left: 10, right: 8, top: 8, bottom: 8 })
-          .backgroundColor(AppTheme.BG_CARD)
-          .borderRadius(AppTheme.RADIUS_MD)
-          .alignItems(VerticalAlign.Center)
-          .onClick(() => {
-            this.openDetailDialog();
+          Text('更多')
+            .fontSize(12)
+            .fontWeight(FontWeight.Medium)
+            .fontColor(AppTheme.ACCENT)
+          AppIcon({
+            src: $r('sys.symbol.chevron_right'),
+            iconSize: 10,
+            color: AppTheme.ACCENT
           })
         }
-        .width('100%')
-        .padding({ left: 12, right: 12, top: 8 })
+        .alignItems(VerticalAlign.Center)
       }
+      .width('100%')
+      .justifyContent(FlexAlign.Start)
+      .alignItems(VerticalAlign.Center)
+      .padding({ left: 12, right: 12, top: 2, bottom: 8 })
+      .onClick(() => {
+        this.openDetailDialog();
+      })
     }
     .width('100%')
     .alignItems(HorizontalAlign.Start)
-    .padding({ bottom: 4 })
   }
 }

--- a/entry/src/main/ets/components/film/PlayDetailPanel.ets
+++ b/entry/src/main/ets/components/film/PlayDetailPanel.ets
@@ -24,7 +24,7 @@ export struct PlayDetailPanel {
   onSelectEpisode?: (sourceId: string, index: number) => void;
   @State private groupSourceIds: string[] = [];
   @State private groupIndexes: number[] = [];
-  @State private headerHeight: number = 148;
+  @State private headerHeight: number = 64;
   @State private ready: boolean = false;
   @StorageLink('WIDTH_BP') private widthBp: string = 'sm';
   private listScroller: Scroller = new Scroller();
@@ -351,7 +351,11 @@ export struct PlayDetailPanel {
   @Builder
   groupBar() {
     Column() {
-      Divider().color(AppTheme.BORDER).width('100%')
+      // 实色不透明白线：保留视觉分区层次，同时 100% 阻断下层滚动内容透光
+      Row()
+        .width('100%')
+        .height(1)
+        .backgroundColor(AppTheme.BORDER_SOLID)
 
       if (this.sources.length > 0) {
         this.sourceRow()
@@ -496,6 +500,7 @@ export struct PlayDetailPanel {
     .animation({ duration: 150, curve: Curve.EaseOut })
     .width('100%')
     .height('100%')
+    .backgroundColor(AppTheme.BG)
     .onAppear(() => {
       this.scrollToFocusedEpisode(false);
       this.syncSourceBar(false);

--- a/entry/src/main/ets/pages/AboutPage.ets
+++ b/entry/src/main/ets/pages/AboutPage.ets
@@ -1,0 +1,413 @@
+import { AppTheme } from '../common/constants/AppTheme';
+import { PageHeader } from '../components/common/PageHeader';
+import { AppIcon } from '../components/common/AppIcon';
+import { WindowBar } from '../common/utils/WindowBar';
+import { NavUtil } from '../common/utils/NavUtil';
+import { AppVersionUtil, AppUpdateInfo } from '../common/utils/AppVersionUtil';
+import { VersionUpdateDialog } from '../components/dialogs/VersionUpdateDialog';
+import { common } from '@kit.AbilityKit';
+import { pasteboard } from '@kit.BasicServicesKit';
+
+interface ProjectLinkItem {
+  title: string;
+  desc: string;
+  url: string;
+  icon: Resource;
+}
+
+@Entry
+@Component
+struct AboutPage {
+  @State private appVersion: string = '1.0.0';
+  @State private isCheckingVersion: boolean = false;
+  @StorageLink('HAS_APP_UPDATE') private hasAppUpdate: boolean = false;
+  @StorageLink('APP_UPDATE_INFO') private updateInfo: AppUpdateInfo = {
+    currentVersion: '', latestVersion: '', hasUpdate: false,
+    releaseName: '', releaseNotes: '', releaseUrl: '', downloadUrl: ''
+  };
+  @State private showUpdateDialog: boolean = false;
+  @State private topInset: number = 0;
+  @State private bottomInset: number = 16;
+  @State private leftInset: number = 0;
+  @State private rightInset: number = 0;
+
+  private readonly projectLinks: ProjectLinkItem[] = [
+    {
+      title: 'EcoHub 开源项目',
+      desc: '服务端、Web 管理后台与前台源码',
+      url: 'https://github.com/fe-spark/EcoHub',
+      icon: $r('sys.symbol.website')
+    },
+    {
+      title: 'EcoHub for OHOS',
+      desc: 'HarmonyOS NEXT 原生客户端源码',
+      url: 'https://github.com/fe-spark/EcoHub-for-OHOS',
+      icon: $r('sys.symbol.phone_1')
+    },
+    {
+      title: 'EcoHub for Android',
+      desc: 'Android 客户端应用源码',
+      url: 'https://github.com/fe-spark/EcoHub-for-Android',
+      icon: $r('sys.symbol.phone_1')
+    },
+    {
+      title: 'Telegram 交流群组',
+      desc: '社区交流、反馈与动态探讨',
+      url: 'https://t.me/ecohub_club',
+      icon: $r('sys.symbol.message_on_message')
+    }
+  ];
+
+  aboutToAppear(): void {
+    const ctx = this.getContextSafe();
+    if (ctx) {
+      WindowBar.apply(ctx, (top: number, bottom: number, left: number, right: number) => {
+        this.topInset = top;
+        this.bottomInset = bottom;
+        this.leftInset = left;
+        this.rightInset = right;
+      });
+    }
+    AppVersionUtil.getVersionName().then((v: string) => {
+      this.appVersion = v;
+    }).catch(() => {});
+
+    // 进入关于页面时静默检查是否有更新，用于状态同步
+    AppVersionUtil.checkUpdate(false).then((info) => {
+      this.updateInfo = info;
+      this.hasAppUpdate = info.hasUpdate;
+    }).catch(() => {});
+  }
+
+  private async handleCheckVersion(force: boolean = false): Promise<void> {
+    if (this.isCheckingVersion) {
+      return;
+    }
+    if (!force && this.hasAppUpdate) {
+      this.showUpdateDialog = true;
+      return;
+    }
+    this.isCheckingVersion = true;
+    try {
+      this.getUIContext().getPromptAction().showToast({ message: '正在检查版本更新...' });
+    } catch (_e) {
+    }
+    try {
+      const info = await AppVersionUtil.checkUpdate(true);
+      this.updateInfo = info;
+      this.hasAppUpdate = info.hasUpdate;
+      if (info.hasUpdate) {
+        this.showUpdateDialog = true;
+      } else {
+        try {
+          this.getUIContext().getPromptAction().showToast({ message: `当前已是最新版本 (v${this.appVersion})` });
+        } catch (_e) {
+        }
+      }
+    } catch (err) {
+      try {
+        this.getUIContext().getPromptAction().showToast({ message: '检查版本失败，请稍后重试' });
+      } catch (_e) {
+      }
+    } finally {
+      this.isCheckingVersion = false;
+    }
+  }
+
+  private getContextSafe(): common.UIAbilityContext | undefined {
+    try {
+      const c = getContext(this) as common.UIAbilityContext;
+      if (c) {
+        return c;
+      }
+    } catch (_e) {}
+    try {
+      return this.getUIContext().getHostContext() as common.UIAbilityContext;
+    } catch (_e) {
+      return undefined;
+    }
+  }
+
+  private copyToClipboard(text: string): void {
+    try {
+      const data = pasteboard.createData(pasteboard.MIMETYPE_TEXT_PLAIN, text);
+      pasteboard.getSystemPasteboard().setDataSync(data);
+      this.getUIContext().getPromptAction().showToast({ message: '链接已复制到剪贴板' });
+    } catch (_e) {
+      try {
+        this.getUIContext().getPromptAction().showToast({ message: '复制失败，请手动复制' });
+      } catch (_err) {}
+    }
+  }
+
+  private openUrl(url: string): void {
+    const ctx = this.getContextSafe();
+    if (ctx) {
+      NavUtil.openBrowser(ctx, url);
+    }
+  }
+
+  @Builder
+  sectionTitle(title: string) {
+    Text(title)
+      .fontSize(13)
+      .fontWeight(FontWeight.Medium)
+      .fontColor(AppTheme.TEXT_MUTED)
+      .padding({ left: 16, right: 16, top: 16, bottom: 8 })
+  }
+
+  @Builder
+  cardDivider() {
+    Divider()
+      .color(AppTheme.BORDER)
+      .margin({ left: 56, right: 16 })
+  }
+
+  build() {
+    Stack({ alignContent: Alignment.Center }) {
+      Column() {
+        PageHeader({ title: '关于' })
+
+        Scroll() {
+          Column({ space: 14 }) {
+            // 1. App 头部基础信息
+            Column() {
+              Image($r('app.media.startIcon'))
+                .width(72)
+                .height(72)
+                .borderRadius(AppTheme.RADIUS_LG)
+                .clip(true)
+                .margin({ bottom: 12 })
+
+              Text('EcoHub')
+                .fontSize(22)
+                .fontWeight(FontWeight.Bold)
+                .fontColor(AppTheme.TEXT_PRIMARY)
+
+              Text(`版本 v${this.appVersion}`)
+                .fontSize(13)
+                .fontColor(AppTheme.TEXT_MUTED)
+                .margin({ top: 4, bottom: 6 })
+
+              Text('自托管高性能多源影视聚合系统')
+                .fontSize(13)
+                .fontColor(AppTheme.TEXT_SECONDARY)
+                .textAlign(TextAlign.Center)
+            }
+            .width('100%')
+            .alignItems(HorizontalAlign.Center)
+            .padding({ top: 16, bottom: 12 })
+
+            // 2. 版本更新卡片
+            Column() {
+              Row() {
+                Row() {
+                  AppIcon({ src: $r('sys.symbol.arrow_counterclockwise'), iconSize: 18, color: AppTheme.ACCENT })
+                }
+                .width(36)
+                .height(36)
+                .justifyContent(FlexAlign.Center)
+                .backgroundColor(AppTheme.ACCENT_SOFT)
+                .borderRadius(18)
+
+                Row() {
+                  Text('版本更新')
+                    .fontSize(15)
+                    .fontWeight(FontWeight.Medium)
+                    .fontColor(AppTheme.TEXT_PRIMARY)
+
+                  if (this.hasAppUpdate) {
+                    Row() {
+                      Text('NEW')
+                        .fontSize(10)
+                        .fontWeight(FontWeight.Bold)
+                        .fontColor(AppTheme.TEXT_PRIMARY)
+                    }
+                    .padding({ left: 6, right: 6, top: 2, bottom: 2 })
+                    .backgroundColor(AppTheme.DANGER)
+                    .borderRadius(AppTheme.RADIUS_PILL)
+                    .margin({ left: AppTheme.SPACE_SM })
+                    .justifyContent(FlexAlign.Center)
+                  }
+                }
+                .layoutWeight(1)
+                .margin({ left: 12, right: 8 })
+                .alignItems(VerticalAlign.Center)
+
+                Text(this.isCheckingVersion
+                  ? '检查中...'
+                  : (this.hasAppUpdate ? `发现新版本 v${this.updateInfo.latestVersion}` : `v${this.appVersion}`))
+                  .fontSize(13)
+                  .fontColor(this.hasAppUpdate ? AppTheme.ACCENT : AppTheme.TEXT_MUTED)
+                  .fontWeight(this.hasAppUpdate ? FontWeight.Medium : FontWeight.Normal)
+                  .margin({ right: 6 })
+
+                AppIcon({
+                  src: $r('sys.symbol.chevron_right'),
+                  iconSize: 14,
+                  color: AppTheme.TEXT_MUTED
+                })
+              }
+              .width('100%')
+              .padding({ left: 16, right: 14, top: 14, bottom: 14 })
+              .alignItems(VerticalAlign.Center)
+            }
+            .backgroundColor(AppTheme.BG_ELEVATED)
+            .borderRadius(AppTheme.RADIUS_LG)
+            .clip(true)
+            .border({ width: 0.5, color: AppTheme.BORDER })
+            .onClick(() => {
+              this.handleCheckVersion();
+            })
+
+            // 3. 相关项目地址列表
+            Column() {
+              this.sectionTitle('相关项目地址')
+
+              Column() {
+                ForEach(this.projectLinks, (item: ProjectLinkItem, index: number) => {
+                  if (index > 0) {
+                    this.cardDivider()
+                  }
+
+                  Row() {
+                    Row() {
+                      AppIcon({ src: item.icon, iconSize: 18, color: AppTheme.ACCENT })
+                    }
+                    .width(36)
+                    .height(36)
+                    .justifyContent(FlexAlign.Center)
+                    .backgroundColor(AppTheme.ACCENT_SOFT)
+                    .borderRadius(18)
+
+                    Column({ space: 3 }) {
+                      Text(item.title)
+                        .fontSize(15)
+                        .fontWeight(FontWeight.Medium)
+                        .fontColor(AppTheme.TEXT_PRIMARY)
+
+                      Text(item.desc)
+                        .fontSize(12)
+                        .fontColor(AppTheme.TEXT_MUTED)
+                        .maxLines(1)
+                        .textOverflow({ overflow: TextOverflow.Ellipsis })
+
+                      Text(item.url)
+                        .fontSize(11)
+                        .fontColor(AppTheme.ACCENT)
+                        .maxLines(1)
+                        .textOverflow({ overflow: TextOverflow.Ellipsis })
+                    }
+                    .alignItems(HorizontalAlign.Start)
+                    .layoutWeight(1)
+                    .margin({ left: 12, right: 8 })
+
+                    // 复制图标按钮
+                    Row() {
+                      AppIcon({
+                        src: $r('sys.symbol.doc_text_on_doc_text'),
+                        iconSize: 16,
+                        color: AppTheme.TEXT_MUTED
+                      })
+                    }
+                    .width(32)
+                    .height(32)
+                    .borderRadius(16)
+                    .justifyContent(FlexAlign.Center)
+                    .backgroundColor('rgba(255, 255, 255, 0.04)')
+                    .margin({ right: 6 })
+                    .onClick(() => {
+                      this.copyToClipboard(item.url);
+                    })
+
+                    // 跳转箭头
+                    AppIcon({
+                      src: $r('sys.symbol.chevron_right'),
+                      iconSize: 14,
+                      color: AppTheme.TEXT_MUTED
+                    })
+                  }
+                  .width('100%')
+                  .padding({ left: 16, right: 14, top: 12, bottom: 12 })
+                  .alignItems(VerticalAlign.Center)
+                  .onClick(() => {
+                    this.openUrl(item.url);
+                  })
+                }, (item: ProjectLinkItem) => item.url)
+              }
+              .backgroundColor(AppTheme.BG_ELEVATED)
+              .borderRadius(AppTheme.RADIUS_LG)
+              .clip(true)
+              .border({ width: 0.5, color: AppTheme.BORDER })
+            }
+            .width('100%')
+            .alignItems(HorizontalAlign.Start)
+
+            // 4. 使用须知卡片
+            Column() {
+              this.sectionTitle('使用须知')
+
+              Column() {
+                Text('EcoHub 为开源自托管影视聚合系统，不提供、不存储任何影视文件。片源来自使用者自行配置的采集接口。请遵守所在地区的法律法规及源站使用约定，仅供学习与技术交流。')
+                  .fontSize(13)
+                  .fontColor(AppTheme.TEXT_SECONDARY)
+                  .lineHeight(20)
+              }
+              .width('100%')
+              .padding(16)
+              .backgroundColor(AppTheme.BG_ELEVATED)
+              .borderRadius(AppTheme.RADIUS_LG)
+              .border({ width: 0.5, color: AppTheme.BORDER })
+            }
+            .width('100%')
+            .alignItems(HorizontalAlign.Start)
+
+            // 5. 版权与开源协议声明
+            Column() {
+              Text('开源协议：MIT License')
+                .fontSize(12)
+                .fontColor(AppTheme.TEXT_MUTED)
+              Text('Copyright © 2026 fe-spark. All Rights Reserved.')
+                .fontSize(11)
+                .fontColor(AppTheme.TEXT_MUTED)
+                .margin({ top: 4 })
+            }
+            .width('100%')
+            .alignItems(HorizontalAlign.Center)
+            .padding({ top: 12, bottom: 24 })
+          }
+          .width('100%')
+          .constraintSize({ maxWidth: AppTheme.CONTENT_MAX_WIDTH })
+          .padding({ left: 16, right: 16, bottom: 24 })
+        }
+        .layoutWeight(1)
+        .width('100%')
+        .scrollBar(BarState.Off)
+        .edgeEffect(EdgeEffect.None)
+        .align(Alignment.Top)
+      }
+      .width('100%')
+      .height('100%')
+      .justifyContent(FlexAlign.Start)
+      .backgroundColor(AppTheme.BG)
+      .padding({
+        top: this.topInset,
+        bottom: this.bottomInset,
+        left: this.leftInset,
+        right: this.rightInset
+      })
+
+      if (this.showUpdateDialog) {
+        VersionUpdateDialog({
+          updateInfo: this.updateInfo,
+          onClose: () => {
+            this.showUpdateDialog = false;
+          }
+        })
+      }
+    }
+    .width('100%')
+    .height('100%')
+    .backgroundColor(AppTheme.BG)
+  }
+}

--- a/entry/src/main/ets/pages/ProfileTab.ets
+++ b/entry/src/main/ets/pages/ProfileTab.ets
@@ -382,67 +382,24 @@ export struct ProfileTab {
           }
           this.menuLine()
           Column() {
-            Row() {
-              Row() {
-                AppIcon({ src: $r('sys.symbol.arrow_counterclockwise'), iconSize: 18, color: AppTheme.ACCENT })
-              }
-              .width(36)
-              .height(36)
-              .justifyContent(FlexAlign.Center)
-              .backgroundColor(AppTheme.ACCENT_SOFT)
-              .borderRadius(18)
-
-              Row() {
-                Text('版本检查')
-                  .fontSize(15)
-                  .fontColor(AppTheme.TEXT_PRIMARY)
-
-                if (this.hasAppUpdate) {
-                  Row() {
-                    Text('NEW')
-                      .fontSize(10)
-                      .fontWeight(FontWeight.Bold)
-                      .fontColor(AppTheme.TEXT_PRIMARY)
-                  }
-                  .padding({ left: 6, right: 6, top: 2, bottom: 2 })
-                  .backgroundColor(AppTheme.DANGER)
-                  .borderRadius(AppTheme.RADIUS_PILL)
-                  .margin({ left: AppTheme.SPACE_SM })
-                  .justifyContent(FlexAlign.Center)
-                }
-              }
-              .layoutWeight(1)
-              .margin({ left: AppTheme.SPACE_MD })
-              .alignItems(VerticalAlign.Center)
-
-              Text(this.isCheckingVersion
-                ? '检查中...'
-                : (this.hasAppUpdate ? `发现新版本 v${this.updateInfo.latestVersion}` : `v${this.appVersion}`))
-                .fontSize(13)
-                .fontColor(this.hasAppUpdate ? AppTheme.ACCENT : AppTheme.TEXT_MUTED)
-                .fontWeight(this.hasAppUpdate ? FontWeight.Medium : FontWeight.Normal)
-                .margin({ right: AppTheme.SPACE_SM })
-
-              AppIcon({
-                src: $r('sys.symbol.chevron_right'),
-                iconSize: 14,
-                color: AppTheme.TEXT_MUTED
-              })
-            }
-            .width('100%')
-            .height(56)
-            .padding({ left: AppTheme.SPACE_LG, right: AppTheme.SPACE_LG })
-            .alignItems(VerticalAlign.Center)
-          }
-          .onClick(() => {
-            this.handleCheckVersion();
-          })
-          this.menuLine()
-          Column() {
             this.menuRow($r('sys.symbol.gearshape'), '设置')
           }
           .onClick(() => {
             NavUtil.openSettings(this.getUIContext());
+          })
+          this.menuLine()
+          Column() {
+            this.menuRow(
+              $r('sys.symbol.info_circle'),
+              '关于',
+              this.hasAppUpdate ? `发现新版本 v${this.updateInfo.latestVersion}` : '',
+              this.hasAppUpdate,
+              'NEW',
+              this.hasAppUpdate
+            )
+          }
+          .onClick(() => {
+            NavUtil.openAbout(this.getUIContext());
           })
         }
         .width('100%')

--- a/entry/src/main/resources/base/profile/main_pages.json
+++ b/entry/src/main/resources/base/profile/main_pages.json
@@ -10,6 +10,7 @@
     "pages/FavoritePage",
     "pages/CustomPlayerPage",
     "pages/TipPage",
-    "pages/SettingsPage"
+    "pages/SettingsPage",
+    "pages/AboutPage"
   ]
 }


### PR DESCRIPTION
## 概述
1. **新增关于页面与入口收敛**：
   - 新增独立关于页面 `pages/AboutPage`，展示项目简介、架构定位、客户端生态链接（Web / OHOS / Android）、社区入口与 MIT 协议。
   - 在关于页面集成应用更新检测能力与 `VersionUpdateDialog` 弹窗联动。
   - 调整个人中心（`ProfileTab`），移除原有“版本检查”直跳项，收敛为统一“关于”入口，并通过角标保留新版本提醒。
2. **影视详情与剧情排版重构**：
   - `FilmDetailHeader`：片名改用顶部对齐并限定最多两行省略；右上角固定收藏胶囊，平抑长短片名视觉重心；元数据流式排布，增加靠左纯文本“更多”直达详情弹窗。
   - `PlayDetailPanel`：精简头部占用高度（148vp -> 64vp），换源分组栏增加实色分割线（`AppTheme.BORDER_SOLID`），彻底消除下层内容滚动穿透。
   - `FormatUtil`：新增 `remarks()` 规则化集数文本；新增 `cleanPlot()` 深度清洗 HTML 标签、实体与多余空白缩进，提升 `FilmDetailDialog` 排版质感。